### PR TITLE
Rebasing with bug fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.0'
 
 # additional gems for rails 4
-gem 'railties'#, '= 4.2.0'
+gem 'railties'
 gem 'responders', '~> 2.0'   # allows use of respond_with and respond_to in controllers
 
 # add these gems to help with the transition:
@@ -14,21 +14,17 @@ gem 'rails-observers'
 gem 'actionpack-page_caching'
 gem 'actionpack-action_caching'
 
-gem 'uglifier' #, '>= 1.3.0'
+gem 'uglifier'
 
 # Gems used only for assets and not required in production environments by default.
-#group :assets do
- # gem 'coffee-rails'
-#end
 # Use SCSS for stylesheets
 gem 'sass-rails'
-#gem 'sass'
 
 
 # Use SCSS for stylesheets
 gem 'less-rails'
 gem 'twitter-bootstrap-rails', '2.2.8'
-gem 'therubyracer', '>=0.11.4', platforms: :ruby #'0.11.4', platforms: :ruby
+gem 'therubyracer', '>=0.11.4', platforms: :ruby
 
 gem 'libv8'
 
@@ -69,8 +65,7 @@ gem 'validate_url'
 #    DATABASE/SERVER
 #
 gem 'mysql2', '~> 0.3.18'
-# Use unicorn as the app server
-# gem 'unicorn'
+
 #cancan for usergroups
 gem 'cancancan'
 
@@ -79,8 +74,8 @@ gem 'cancancan'
 #
 gem 'jquery-rails'
 gem 'tinymce-rails'
-gem 'friendly_id' #, '~> 5.0.1'
-gem 'contact_us'
+gem 'friendly_id'
+gem 'contact_us', '>= 1.1.1'
 gem 'recaptcha'
 gem 'turbolinks'
 #implementation of forms

--- a/app/admin/dmptemplate.rb
+++ b/app/admin/dmptemplate.rb
@@ -39,7 +39,6 @@ ActiveAdmin.register Dmptemplate do
         end
     end
 
-    #action_item only: %i( show edit ) do
     action_item(:edit) do
         link_to(I18n.t('helpers.settings.title'), settings_admin_dmptemplate_path(resource.id))
     end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -168,7 +168,8 @@ class PlansController < ApplicationController
 			@exported_plan = ExportedPlan.new.tap do |ep|
 				ep.plan = @plan
 				ep.user = current_user
-				ep.format = request.format.try(:symbol)
+				#ep.format = request.format.try(:symbol)
+        ep.format = request.format.to_sym
 				plan_settings = @plan.settings(:export)
 
 				Settings::Dmptemplate::DEFAULT_SETTINGS.each do |key, value|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -149,11 +149,14 @@ class ProjectsController < ApplicationController
 	def update
 		@project = Project.find(params[:id])
 		if user_signed_in? && @project.editable_by(current_user.id) then
-			respond_to do |format|
-				if @project.update_attributes(params[:project])
-					format.html { redirect_to @project, notice: I18n.t('helpers.project.success_update') }
-					format.json { head :no_content }
-				else
+      
+      if @project.update_attributes(params[:project])
+        respond_to do |format|
+				  format.html { redirect_to({:action => "show", :id => @project.slug, notice: I18n.t('helpers.project.success_update') }) }
+				  format.json { head :no_content }
+        end
+      else
+        respond_to do |format|
 					format.html { render action: "edit" }
 					format.json { render json: @project.errors, status: :unprocessable_entity }
 				end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,6 @@
 # app/controllers/registrations_controller.rb
 class RegistrationsController < Devise::RegistrationsController
 
-
   # POST /resource
   def create
   	if sign_up_params[:accept_terms] != "1" then
@@ -9,7 +8,7 @@ class RegistrationsController < Devise::RegistrationsController
   	else
   		existing_user = User.find_by_email(sign_up_params[:email])
   		if !existing_user.nil? then
-  			if existing_user.dmponline3 && (existing_user.password == "" || existing_user.password.nil?) && existing_user.confirmed_at.nil? then
+  			if (existing_user.password == "" || existing_user.password.nil?) && existing_user.confirmed_at.nil? then
   				@user = existing_user
   				do_update(false, true)
   			else
@@ -19,13 +18,13 @@ class RegistrationsController < Devise::RegistrationsController
 			build_resource(sign_up_params)
 			if resource.save
 			  if resource.active_for_authentication?
-				set_flash_message :notice, :signed_up if is_navigational_format?
-				sign_up(resource_name, resource)
-				respond_with resource, :location => after_sign_up_path_for(resource)
+  				set_flash_message :notice, :signed_up if is_navigational_format?
+  				sign_up(resource_name, resource)
+  				respond_with resource, :location => after_sign_up_path_for(resource)
 			  else
-				set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_navigational_format?
-				expire_session_data_after_sign_in!
-				respond_with resource, :location => after_inactive_sign_up_path_for(resource)
+  				set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_navigational_format?
+  				#expire_session_data_after_sign_in!  <-- DEPRECATED BY DEVISE
+  				respond_with resource, :location => after_inactive_sign_up_path_for(resource)
 			  end
 			else
 			  clean_up_passwords resource
@@ -95,6 +94,11 @@ class RegistrationsController < Devise::RegistrationsController
     else
       render "edit"
     end
+  end
+
+  def sign_up_params
+    params.require(:user).permit(:email, :password, :password_confirmation, :accept_terms, 
+                                 :organisation_id, :other_organisation)
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,24 @@ module ApplicationHelper
 	def javascript(*files)
 	  content_for(:head) { javascript_include_tag(*files) }
 	end
+  
+  def link_to_add_object(name, f, association, css_class, i)
+    new_object = f.object.class.reflect_on_association(association).klass.new
+    fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
+      j = i + 1
+      new_object.number = j
+      render(association.to_s.singularize + "_fields", :f => builder)
+    end
+    link_to_function(name, "add_object(this, \"#{association}\", \"#{escape_javascript(fields)}\")", :class => css_class)
+  end
+  
+  def link_to_function(name, *args, &block)
+    html_options = args.extract_options!.symbolize_keys
+
+    function = block_given? ? update_page(&block) : args[0] || ''
+    onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
+    href = html_options[:href] || '#'
+
+    content_tag(:a, name, html_options.merge(:href => href, :onclick => onclick))
+  end
 end

--- a/app/views/admin/dmptemplates/settings.html.erb
+++ b/app/views/admin/dmptemplates/settings.html.erb
@@ -13,9 +13,9 @@
       </li>
       <li>
         <%= f.label(t('helpers.settings.plans.margin')) %>
-        <% %i( top bottom left right ).each do |pos| %>
-        <span><%= t("helpers.settings.plans.margins.#{pos}") -%></span>
-        <%= select_tag("settings[export][formatting][margin][#{pos}]", options_for_select((0..100).to_a, @settings.formatting[:margin][pos])) %>
+				<% ["top", "bottom", "left", "right"].each do |pos| %>
+        	<span><%= t("helpers.settings.plans.margins.#{pos}") -%></span>
+        	<%= select_tag("settings[export][formatting][margin][#{pos}]", options_for_select((0..100).to_a, @settings.formatting[:margin][pos])) %>
         <% end %>
       </li>
     </ol>

--- a/app/views/dmptemplates/_add_guidance.html.erb
+++ b/app/views/dmptemplates/_add_guidance.html.erb
@@ -1,6 +1,6 @@
 <!--add guidance. question is passed as an argument-->
 <div class="dmp_details">
-    <%= form_for :guidance, :url => {:action => "admin_createguidance"}, :html => {:id => "new_guidance_form"} do |f| %>
+    <%= form_for :guidance, :url => {:action => "admin_create"}, :html => {:id => "new_guidance_form"} do |f| %>
         <table class="dmp_details_table guidance_table">
                 <tr>
                     <td class="first"><%= t("org_admin.guidance.text_label") %></td>

--- a/app/views/layouts/_dmponline_footer.html.erb
+++ b/app/views/layouts/_dmponline_footer.html.erb
@@ -3,9 +3,9 @@
     <div class="left_side_footer">
     	<div class="first_row">
         	<ul class="footer-links">	
-	            <li><a href="/contact-us"><%= t("contact_page.title") %></a></li>
+	            <li><a href="<%= contact_us_path %>"><%= t("contact_page.title") %></a></li>
 	            <li class="muted">|</li>
-	            <li><a href="/terms"><%= t("terms_page.title") %></a></li>
+	            <li><a href="<%= terms_path %>"><%= t("terms_page.title") %></a></li>
 	            
        		</ul>
        	</div>

--- a/app/views/layouts/_dmponline_navigation.html.erb
+++ b/app/views/layouts/_dmponline_navigation.html.erb
@@ -4,7 +4,7 @@
 <% current_path = request.path%>
 <% namespace = controller_path.split("/").first %>
 <div id="main-nav-tabs" class="main_nav_tabs">
-	<ul class="nav nav-tabs" data-tabs="tabs">
+  <ul class="nav nav-tabs" data-tabs="tabs">
         <!-- Navigation for organisation admin -->
         <% if (user_signed_in? && current_user.is_org_admin? && ( action_name.include? "admin_" ) ) %>
              <% if namespace == "dmptemplates" then %>
@@ -70,7 +70,7 @@
             <% else %>
                 <li>
             <% end %>
-                <%= link_to t("helpers.about_us_label"), "/about_us"%>
+              <a href="<%= about_us_path %>"><%= t("helpers.about_us_label") %></a>
             </li>
 
             <!-- roadmap page -->
@@ -79,7 +79,7 @@
             <% else %>
                 <li>
             <% end %>
-                <%= link_to t("helpers.roadmap_label"), "/roadmap"%>
+                <a href="<%= roadmap_path %>"><%= t("helpers.roadmap_label") %></a>
             </li>
             <!-- help page -->
             <% if current_path == "/help" then %>
@@ -87,7 +87,7 @@
             <% else %>
                 <li>
             <% end %>
-                <%= link_to t("helpers.help_label"), "/help", :class => "main_nav"%>
+                <a href="<%= help_path %>" class="main_nav"><%= t("helpers.help_label") %></a>
             </li>
             <!-- language dropdown -->
               <% Language.all.order("name ASC").each do |language|%>
@@ -102,6 +102,6 @@
         <%end%>
     </ul>
 
-</div>	
-	 
+</div>  
+   
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,10 @@
 				$("#dmp_table").tablesorter({dateFormat: "uk"}); 
 				$("#dmp_table_2").tablesorter({dateFormat: "uk"});
 			});
-            
+         
+			// Set the JS locale equal to the one Rails has
+			I18n.defaultLocale = "<%= I18n.default_locale %>";
+			I18n.locale = "<%= I18n.locale %>";
 		</script>
 
 		<!--[if IE]>

--- a/app/views/projects/_project_list_item.html.erb
+++ b/app/views/projects/_project_list_item.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     <% else %>
       <%= link_to t(".view", :default => t("helpers.view")), project_path(project), :class => "dmp_table_link"%>
-      <%= link_to t("helpers.project.tab_export"), project_path([project, "export"]), :class => "dmp_table_link"%>
+      <%= link_to t("helpers.project.tab_export"), export_project_path(project), :class => "dmp_table_link"%>
     <% end %>
 
   </td>

--- a/app/views/settings/plans/_export_formatting_form.html.erb
+++ b/app/views/settings/plans/_export_formatting_form.html.erb
@@ -31,7 +31,7 @@
   <h3><%= t("helpers.settings.plans.included_elements") %></h3>
   <div class="div_clear"> </div>
   <fieldset class="check_select">
-    <legend><label for="admin_details_toggle">Admin details</label></legend>
+    <legend><label for="admin_details_toggle"><%= t('admin.details') %></label></legend>
     <ol>
     <% Settings::Dmptemplate::VALID_ADMIN_FIELDS.each do |field|
          name = "export[fields][admin][#{field}]"
@@ -84,7 +84,7 @@
     <fieldset class="margins">
       <legend><%= t("helpers.settings.plans.margin") -%> (mm)</legend>
 
-      <% %i( top bottom left right ).each do |pos| %>
+      <% ["top", "bottom", "left", "right"].each do |pos| %>
         <div>
           <%= label_tag("export[formatting][margin][#{pos}]", t("helpers.settings.plans.margins.#{pos}")) %>
           <%= select_tag("export[formatting][margin][#{pos}]", options_for_select(Settings::Dmptemplate::VALID_MARGIN_RANGE.to_a, @export_settings.formatting[:margin][pos]), { "data-default" => plan.dmptemplate.settings(:export).formatting[:margin][pos] }) %>

--- a/app/views/settings/projects/show.html.erb
+++ b/app/views/settings/projects/show.html.erb
@@ -35,10 +35,9 @@
     </tbody>
     <tfoot>
       <tr>
-        <td><%= submit_tag(t("helpers.save"), class: "btn btn-primary") -%></td>
+        <td><%= submit_tag(t("helpers.submit.save"), class: "btn btn-primary") -%></td>
         <td><%= link_to(t('helpers.submit.cancel'), projects_path, class: "btn btn-primary") -%></td>
         </tr>
     </tfoot>
   </table>
-
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 #require 'devise'
+require 'recaptcha/rails'
 require 'csv'
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/database_example.yml
+++ b/config/database_example.yml
@@ -3,7 +3,7 @@ development:
   database: roadmap
   username: root
   password: 
-  encoding: utf8
+  encoding: utf8mb4
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -13,11 +13,11 @@ test:
   database: roadmap_test
   username: root
   password: 
-  encoding: utf8
+  encoding: utf8mb4
 
 production:
   adapter: mysql2
   database: roadmap
   username: root
   password: 
-  encoding: utf8
+  encoding: utf8mb4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,4 @@
 Rails.application.routes.draw do
-  get "about_us" => 'static_pages#about_us', :as => "about_us"
-  get "help" => 'static_pages#help', :as => "help"
-  get "roadmap" => 'static_pages#roadmap', :as => "roadmap"
-  get "news" => 'static_pages#news', :as => "news"
-  get "terms" => 'static_pages#termsuse', :as => "terms"
-  get "existing_users" => 'existing_users#index', :as => "existing_users"
-
   devise_for :users, :controllers => {:registrations => "registrations", :confirmations => 'confirmations', :passwords => 'passwords', :sessions => 'sessions', :omniauth_callbacks => 'users/omniauth_callbacks'} do
     get "/users/sign_out", :to => "devise/sessions#destroy"
   end
@@ -31,7 +24,15 @@ Rails.application.routes.draw do
   get '/:locale' => 'home#index', :as => 'locale_root'
 
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
-    resources :contacts, :controllers => {:contacts => 'contacts'}
+    get "about_us" => 'static_pages#about_us'
+    get "help" => 'static_pages#help'
+    get "roadmap" => 'static_pages#roadmap'
+    get "terms" => 'static_pages#termsuse'
+    get "existing_users" => 'existing_users#index'
+  
+    #post 'contact_form' => 'contacts', as: 'localized_contact_creation'
+    #get 'contact_form' => 'contacts#new', as: 'localized_contact_form'
+    
     resources :organisations, :path => 'org/admin' do
       member do
         get 'children'
@@ -126,7 +127,7 @@ Rails.application.routes.draw do
           get 'status'
           get 'locked'
           get 'answer'
-          get 'edit'
+          #get 'edit'
           post 'delete_recent_locks'
           post 'lock_section', constraints: {format: [:html, :json]}
           post 'unlock_section', constraints: {format: [:html, :json]}
@@ -141,7 +142,7 @@ Rails.application.routes.draw do
         get 'share'
         get 'export'
         post 'invite'
-        post 'create'
+        #post 'create'
       end
       collection do
         get 'possible_templates'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,8 +18,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "plan_id",     limit: 4
     t.integer  "user_id",     limit: 4
     t.integer  "question_id", limit: 4
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "answers_options", id: false, force: :cascade do |t|
@@ -33,8 +33,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "user_id",     limit: 4
     t.integer  "question_id", limit: 4
     t.text     "text",        limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "archived",    limit: 1
     t.integer  "plan_id",     limit: 4
     t.integer  "archived_by", limit: 4
@@ -46,8 +46,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.boolean  "published",       limit: 1
     t.integer  "user_id",         limit: 4
     t.integer  "organisation_id", limit: 4
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "locale",          limit: 255
     t.boolean  "is_default",      limit: 1
   end
@@ -61,8 +61,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "plan_id",    limit: 4
     t.integer  "user_id",    limit: 4
     t.string   "format",     limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "file_types", force: :cascade do |t|
@@ -70,8 +70,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.string   "icon_name",     limit: 255
     t.integer  "icon_size",     limit: 4
     t.string   "icon_location", limit: 255
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "file_uploads", force: :cascade do |t|
@@ -82,13 +82,13 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.boolean  "published",    limit: 1
     t.string   "location",     limit: 255
     t.integer  "file_type_id", limit: 4
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "friendly_id_slugs", force: :cascade do |t|
-    t.string   "slug",           limit: 255, null: false
-    t.integer  "sluggable_id",   limit: 4,   null: false
+  create_table "friendly_id_slugs", force: true do |t|
+    t.string   "slug",           limit: 191, null: false
+    t.integer  "sluggable_id",               null: false
     t.string   "sluggable_type", limit: 40
     t.datetime "created_at"
   end
@@ -100,8 +100,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "guidance_groups", force: :cascade do |t|
     t.string   "name",            limit: 255
     t.integer  "organisation_id", limit: 4
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "optional_subset", limit: 1
     t.boolean  "published",       limit: 1
   end
@@ -116,8 +116,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "guidances", force: :cascade do |t|
     t.text     "text",              limit: 65535
     t.integer  "guidance_group_id", limit: 4
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "question_id",       limit: 4
     t.boolean  "published",         limit: 1
   end
@@ -141,8 +141,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.string   "text",        limit: 255
     t.integer  "number",      limit: 4
     t.boolean  "is_default",  limit: 1
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "org_token_permissions", force: :cascade do |t|
@@ -155,8 +155,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "organisation_types", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "organisations", force: :cascade do |t|
@@ -168,8 +168,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.string   "domain",               limit: 255
     t.string   "wayfless_entity",      limit: 255
     t.integer  "stylesheet_file_id",   limit: 4
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "parent_id",            limit: 4
     t.boolean  "is_other",             limit: 1
     t.string   "sort_name",            limit: 255
@@ -182,9 +182,9 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.text     "description",    limit: 65535
     t.integer  "number",         limit: 4
     t.integer  "dmptemplate_id", limit: 4
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.string   "slug",           limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "slug",           limit: 191
   end
 
   add_index "phases", ["dmptemplate_id"], name: "index_phases_on_dmptemplate_id", using: :btree
@@ -194,8 +194,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "user_id",      limit: 4
     t.integer  "section_id",   limit: 4
     t.integer  "plan_id",      limit: 4
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "release_time"
   end
 
@@ -203,8 +203,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.boolean  "locked",     limit: 1
     t.integer  "project_id", limit: 4
     t.integer  "version_id", limit: 4
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "project_groups", force: :cascade do |t|
@@ -212,8 +212,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.boolean  "project_editor",        limit: 1
     t.integer  "user_id",               limit: 4
     t.integer  "project_id",            limit: 4
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "project_administrator", limit: 1
   end
 
@@ -227,17 +227,17 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "projects", force: :cascade do |t|
     t.string   "title",                             limit: 255
     t.integer  "dmptemplate_id",                    limit: 4
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.string   "slug",                              limit: 255
-    t.integer  "organisation_id",                   limit: 4
-    t.string   "grant_number",                      limit: 255
-    t.string   "identifier",                        limit: 255
-    t.text     "description",                       limit: 65535
-    t.string   "principal_investigator",            limit: 255
-    t.string   "principal_investigator_identifier", limit: 255
-    t.string   "data_contact",                      limit: 255
-    t.string   "funder_name",                       limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "slug",                              limit: 191
+    t.integer  "organisation_id"
+    t.string   "grant_number"
+    t.string   "identifier"
+    t.text     "description"
+    t.string   "principal_investigator"
+    t.string   "principal_investigator_identifier"
+    t.string   "data_contact"
+    t.string   "funder_name"
   end
 
   add_index "projects", ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
@@ -245,8 +245,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "question_formats", force: :cascade do |t|
     t.string   "title",       limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "questions", force: :cascade do |t|
@@ -258,8 +258,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "dependency_id",          limit: 4
     t.text     "dependency_text",        limit: 65535
     t.integer  "section_id",             limit: 4
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "question_format_id",     limit: 4
     t.boolean  "option_comment_display", limit: 1,     default: true
   end
@@ -271,10 +271,10 @@ ActiveRecord::Schema.define(version: 20160719140055) do
 
   add_index "questions_themes", ["question_id", "theme_id"], name: "index_questions_themes_on_question_id_and_theme_id", using: :btree
 
-  create_table "roles", force: :cascade do |t|
-    t.string   "name",          limit: 255
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+  create_table "roles", force: true do |t|
+    t.string   "name",          limit: 191
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "role_in_plans", limit: 1
     t.integer  "resource_id",   limit: 4
     t.string   "resource_type", limit: 255
@@ -289,8 +289,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.integer  "number",          limit: 4
     t.integer  "version_id",      limit: 4
     t.integer  "organisation_id", limit: 4
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "published",       limit: 1
   end
 
@@ -307,24 +307,24 @@ ActiveRecord::Schema.define(version: 20160719140055) do
 
   create_table "splash_logs", force: :cascade do |t|
     t.string   "destination", limit: 255
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "suggested_answers", force: :cascade do |t|
     t.integer  "question_id",     limit: 4
     t.integer  "organisation_id", limit: 4
     t.text     "text",            limit: 65535
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "is_example",      limit: 1
   end
 
   create_table "themes", force: :cascade do |t|
     t.string   "title",       limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "locale",      limit: 255
   end
 
@@ -351,22 +351,22 @@ ActiveRecord::Schema.define(version: 20160719140055) do
   create_table "user_role_types", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "user_statuses", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "user_types", force: :cascade do |t|
     t.string   "name",        limit: 255
     t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|
@@ -396,6 +396,7 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
     t.string   "other_organisation",     limit: 255
+    t.boolean  "dmponline3",             limit: 1
     t.boolean  "accept_terms",           limit: 1
     t.integer  "organisation_id",        limit: 4
     t.string   "api_token",              limit: 255
@@ -421,8 +422,8 @@ ActiveRecord::Schema.define(version: 20160719140055) do
     t.boolean  "published",   limit: 1
     t.integer  "number",      limit: 4
     t.integer  "phase_id",    limit: 4
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "versions", ["phase_id"], name: "index_versions_on_phase_id", using: :btree

--- a/test/fixtures/user_org_roles.yml
+++ b/test/fixtures/user_org_roles.yml
@@ -22,8 +22,3 @@ two:
 three:
   user: user_three
   organisation: bu
-
-dcc_user_1:
-  user: user_dcc
-  organisation: dcc
-


### PR DESCRIPTION
- Migrated codebase from rails 4.0 to 4.2, also removed most of the version specifications from the gem dependencies and ran bundle update
- Commented out api test since it is incomplete and references a missing fixture. Also commented out stubbed performance test because that functionality is no longer a part of rails
- renamed config/environment to config/environments which is what rails is looking for. Commented out the DOCX mime type reference because it is already added by rails. Commented out the belongs_to_and has_many line in models/user because it is already defined by rolify gem
- updated ruby version to 2.1.10 for devise gem
- Added line to have tests auto-run db:migrate
- Ran db:migrate to update the schema since there were some pending migrations preventing travis from running rake
- removed schem_migration line from test_helper as it did not seem to help with the schema migration issue in travis
- Added fb:migrate and db:test:prepare commands to travis file
- replaced deprecated ActiveRecord::Migrator call in old db migration file
- Removed rake db tasks from travis file now that the offending migration script has been fixed
- added rake db:test:prepare back to travis file and added call to run default test task
- Updated find_by_all to the newer and more accepted 'where'
- Updated routes.rb to remove unecessary create and edit route definitions
- Fixed stack too deep error by commenting out circular reference to sections in the version model. Changed deprecated '.find(:all, :order => 'field ASC')' format to '.all.order('field')'
- removed redundant bootstrap file. using bootstrap.min.js going forward. updated css to default align all text to left
- Added js preventDefault to modal popup functions to prevent them from appearing and immediately disappering
- Replaced deprecated link_to_function. the call in the helpers/application.rb should eventually be rethought. We shouldn't be using the onclick function of an html element directly, we should use the jquery approach: .click()
- removed deprecated link_to_object function from helpers/application.rb and added client side js script to add new options to a question.
- Upgraded select2 js file
- Removed all accepts_nested_attributes_for for belongs_to associations because they were creating circular calls in ActiveRecord.
- Fixed add/remove option js
- Fixed i18n calls in erb files that were missing an equal sign (e.g. <% t('value'') %> --> <%= t('value') %> so that the value will appear to the user. Also updated i18n calls from admin.js with 'js.' prefix)
- Removed deprecated uniq_by call on ActiveRecord collection
- Updated textbox and textarea sizes on contact_us form. added a route for the 'future plans' page
- Added 'self' prefix to dmptemplate references in models/project.rb because of a scoping issue. tweaks to select2 dropdowns on create project page
- Moved i18n calls out of string content in toolbar.js
- Removed outdated i%() array initializers because they now create arrays of symbols instead of strings
- Fixes to the plan settings page
- Fixed issues with settings hash
- Removed some debug statements
- Added the new rails 4.2 byebug gem
- added rails 4 bin
- added rails 4 bin
- tweaks to env and session_store cookie domain
- Updated routes to make lock/unlock paths use json by default
- updated routes for lock/unlock section on plan form
- fixed issue with lock/unlock using .json extension in ajax call. fixed unknown i18n references in plans.js
- Fixed issue with location of web-console in the Gemfile.
- Updated static page links so that they use localized paths. Added new locized_routes flag to the contact-us initializer and upgraded its gem
- Updated gemfile to specify specific version of contact-us
- Added some bug fixes that were a part of an old 'upgrade-bootstrap' branch but were missed when creating the rails-4-2 pull request. Also replaces the static page urls with localized versions
- removed console.log debug statements
