### PR TITLE
Various post-migration fixes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -40,7 +40,7 @@ class NotesController < ApplicationController
       plan = answer.plan
       owner = plan.owner
       deliver_if(recipients: owner, key: 'users.new_comment') do |r|
-        UserMailer.new_comment(r, plan).deliver_now()
+        UserMailer.new_comment(current_user, plan).deliver_now()
       end
       @notice = success_message(_('comment'), _('created'))
       render(json: {

--- a/app/controllers/paginable/orgs_controller.rb
+++ b/app/controllers/paginable/orgs_controller.rb
@@ -17,7 +17,7 @@ module Paginable
       authorize(Org)
       paginable_renderise(
         partial: 'index',
-        scope: Org.includes(:templates, :users).joins(:templates, :users),
+        scope: Org.includes(:templates, :users),
         query_params: { sort_field: 'orgs.name', sort_direction: :asc }
       )
     end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -262,7 +262,7 @@ class PlansController < ApplicationController
       format.html { render layout: false }
       format.csv  { send_data @plan.as_csv(@show_sections_questions),  filename: "#{file_name}.csv" }
       format.text { send_data render_to_string(partial: 'shared/export/plan_txt'), filename: "#{file_name}.txt" }
-      format.docx { render docx: 'export', filename: "#{file_name}.docx" }
+      format.docx { render docx: "#{file_name}.docx", content: render_to_string(partial: 'shared/export/plan') }
       format.pdf do
         render pdf: file_name,
           margin: @formatting[:margin],

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -49,11 +49,10 @@ class RegistrationsController < Devise::RegistrationsController
     else
       existing_user = User.where_case_insensitive('email', sign_up_params[:email]).first
       if existing_user.present?
-        if existing_user.invitation_token.present? && 
-             !existing_user.accept_terms?
-          existing_user.destroy # Destroys the existing user since the accept terms are nil/false.
+        if existing_user.invitation_token.present? && !existing_user.accept_terms?
+          existing_user.destroy # Destroys the existing user since the accept terms are nil/false. and they have an invitation
           # Note any existing role for that user will be deleted too. Added to accommodate issue at:
-          # https://github.com/DMPRoadmap/roadmap/issues/322
+          # https://github.com/DMPRoadmap/roadmap/issues/322 when invited user creates an account outside the invite workflow
         else
           redirect_to after_sign_up_error_path_for(resource), alert: _('That email address is already registered.')
           return

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -4,7 +4,7 @@ module SuperAdmin
 
     def index
       authorize Org
-      render 'index', locals: { orgs: Org.includes(:templates, :users).joins(:templates, :users) }
+      render 'index', locals: { orgs: Org.includes(:templates, :users) }
     end
     
     def new

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -218,7 +218,8 @@ class Plan < ActiveRecord::Base
 
         if self.save!
           # Send an email confirmation to the owners and co-owners
-          deliver_if(recipients: self.owner_and_coowners, key: 'users.feedback_requested') do |r|
+          owners = User.joins(:roles).where('roles.plan_id =? AND roles.access IN (?)', self.id, Role.access_values_for(:administrator))
+          deliver_if(recipients: owners, key: 'users.feedback_requested') do |r|
             UserMailer.feedback_confirmation(r, self, user).deliver_now
           end
           # Send an email to all of the org admins as well as the Org's administrator email
@@ -255,8 +256,9 @@ class Plan < ActiveRecord::Base
         
         if self.save!
           # Send an email confirmation to the owners and co-owners
-          deliver_if(recipients: self.owner_and_coowners, key: 'users.feedback_provided') do |r|
-            UserMailer.feedback_notification(r, self, org_admin).deliver_now
+          owners = User.joins(:roles).where('roles.plan_id =? AND roles.access IN (?)', self.id, Role.access_values_for(:administrator))
+          deliver_if(recipients: owners, key: 'users.feedback_provided') do |r|
+            UserMailer.feedback_complete(r, self, org_admin).deliver_now
           end
           true
         else

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -40,7 +40,7 @@
             <% end %>
 
             <% answer = @plan.answer(question[:id], false) %>
-            <% blank = answer.present? ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
+            <% blank = (answer.present? && answer.is_valid?) ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
             <% if blank && @show_unanswered %>
               <p><%= _('Question not answered.') -%></p>
             <% elsif !blank %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -39,7 +39,7 @@
         <% end %>
       <% end %>
       <% answer = @plan.answer(question[:id], false) %>
-      <% blank = answer.present? ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
+      <% blank = (answer.present? && answer.is_valid?) ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
       <% if blank && @show_unanswered %>
 <%= "    #{_("Question not answered.")}\n\n" %>
       <% elsif !blank %>

--- a/app/views/static_pages/help.html.md
+++ b/app/views/static_pages/help.html.md
@@ -1,99 +1,75 @@
-<h1>Quick start guide</h1>
+<h1><%= _('Quick start guide') %></h1>
 <hr>
 
-<h3>Contents</h3>
+<h3><%= _('Contents') %></h3>
 
-[Who can use the tool?](#who-can-use-the-tool)   
-[How do I log in or create an account?](#how-do-i-log-in-or-create-an-account)   
-[Overview of My dashboard](#overview-of-my-dashboard)   
-[How do I create a data management plan?](#how-do-i-create-a-data-management-plan)   
-[How do I get help from someone at my institution?](#how-do-i-get-help-from-someone-at-my-institution)   
+[<%= _('Who can use the tool?') %>](#who-can-use-the-tool)   
+[<%= _('How do I log in or create an account?') %>](#how-do-i-log-in-or-create-an-account)   
+[<%= _('Overview of My dashboard') %>](#overview-of-my-dashboard)   
+[<%= _('How do I create a data management plan?') %>](#how-do-i-create-a-data-management-plan)   
+[<%= _('How do I get help from someone at my institution?') %>](#how-do-i-get-help-from-someone-at-my-institution)   
 <hr>
 
-<h3 id="who-can-use-the-tool">Who can use the tool?</h3>
+<h3 id="who-can-use-the-tool"><%= _('Who can use the tool?') %></h3>
 
-DMPTool is free for anyone to create data management plans. As a user, you can:   
-<ul>
-<li>Create your own plans.</li>
-<li>Co-author a plan with collaborators.</li>
-<li> If you are a researcher from one of the <a href="https://dmptool.org/public_orgs\" target="_blank">participating institutions</a>, you can log in using your institutional credentials. You may then be presented with institution-specific guidance and have the option to get feedback from local data experts.</li></ul>
+<%= raw _('DMPTool is free for anyone to create data management plans. As a user, you can:<ul><li>Create your own plans.</li><li>Co-author a plan with collaborators.</li><li> If you are a researcher from one of the <a href="https://dmptool.org/public_orgs\">participating institutions</a>, you can log in using your institutional credentials. You may then be presented with institution-specific guidance and have the option to get feedback from local data experts.</li></ul>') %>
 <hr>
 
-<h3 id="how-do-i-log-in-or-create-an-account">How do I log in or create an account?</h3>
+<h3 id="how-do-i-log-in-or-create-an-account"><%= _('How do I log in or create an account?') %></h3>
 
-Click on Sign in at the top-right of the home page. You can also click the white “Get started” button.   
+<%= _('Click on Sign in at the top-right of the home page. You can also click the white “Get started” button.') %>
 
-If your institution/organization is affiliated with DMPTool:
-<ul>
-<li>Click the first button to sign in with “Your institution.”</li>
-<li>Select your institution from the list and click “Go.”</li>
-<li>Researchers at some institutions will be presented with the institution's authentication page. Log in as you usually do for your institution’s web services.</li>
-<li>If your institution has not configured single sign-on, you need to create an account with DMPTool (last bullet).</li>
-<li>If you have already created an account with DMPTool, click the second button to sign in with the email address and password you previously chose. Once logged in, use Edit profile in the top-right menu bar to manage your password and other information.</li>
-<li>If your institution is not affiliated with DMPTool (or has not configured single sign-on), you need to create an account with an email address and password.</li></ul>
+<%= raw _('If your institution/organization is affiliated with DMPTool:<ul><li>Click the first button to sign in with “Your institution.”</li><li>Select your institution from the list and click “Go.”</li><li>Researchers at some institutions will be presented with the institution\\'s authentication page. Log in as you usually do for your institution\\’s web services.</li><li>If your institution has not configured single sign-on, you need to create an account with DMPTool (last bullet).</li><li>If you have already created an account with DMPTool, click the second button to sign in with the email address and password you previously chose. Once logged in, use Edit profile in the top-right menu bar to manage your password and other information.</li><li>If your institution is not affiliated with DMPTool (or has not configured single sign-on), you need to create an account with an email address and password.</li></ul>') %>
 
 <img src="https://github.com/CDLUC3/dmptool/blob/master/docs/quickstartguide/UCR-signin-ai.png?raw=true" alt="UCR sign in" style="width: 40%; margin-left: 45px;" />
 
 <hr>
   
-<h3 id="overview-of-my-dashboard">Overview of My dashboard</h3>
+<h3 id="overview-of-my-dashboard"><%= _('Overview of My dashboard') %></h3>
 
-When you log in you will be directed to “My dashboard.” From here you can create, edit, share, download, copy, or remove any of your plans. You will also see plans that have been shared with you by others.    
+<%= _('When you log in you will be directed to “My dashboard.” From here you can create, edit, share, download, copy, or remove any of your plans. You will also see plans that have been shared with you by others.') %>
 
-If others at your institution/organization have chose to share their plans internally, you will see a second table of organizational plans. This allows you to download a PDF and view their plans as samples or to discover new research data. Additional samples are available in the list of <a href="https://dmptool.org/public_plans\" target="_blank">public plans</a>.   
+<%= raw _('If others at your institution/organization have chose to share their plans internally, you will see a second table of organizational plans. This allows you to download a PDF and view their plans as samples or to discover new research data. Additional samples are available in the list of <a href="https://dmptool.org/public_plans\" target="_blank">public plans</a>.') %>
 
 <img src="https://github.com/CDLUC3/dmptool/blob/master/docs/quickstartguide/my-dashboard-ai.png?raw=true" alt="My dashboard" style="width: 80%; margin-left: 45px;" />
 <hr> 
 
-<h3 id="how-do-i-create-a-data-management-plan">How do I create a data management plan?</h3>
+<h3 id="how-do-i-create-a-data-management-plan"><%= _('How do I create a data management plan?') %></h3>
 <br>
-<h4>Create a plan</h4>
+<h4><%= _('Create a plan') %></h4>
 
-To create a plan, click the “Create plan” button on My dashboard or the top menu. This will take you to a wizard that helps you select the appropriate template:   
+<%= _('To create a plan, click the “Create plan” button on My dashboard or the top menu. This will take you to a wizard that helps you select the appropriate template:') %>
 
 <img src="https://github.com/CDLUC3/dmptool/blob/master/docs/quickstartguide/create-plan-ai.png?raw=true" alt="Create plan" style="width: 70%; margin-left: 45px;" />
 
-<ol type="1">
-<li>Enter a title for your research project. If applying for funding, use the project title as it appears in the proposal.</li>
-<li>Select the primary research organization. If you are associated with a participating institution/organization, this field will be pre-populated. You have the option to clear the field and select another organization from the list. Based on your selection, you will be presented with institution-specific templates and guidance. You can also check the box that “No organization is associated with this plan.”</li>
-<li>Select the primary funding organization. If you are required to include a data management plan as part of a grant proposal, select your funder from the list. You may be presented with a secondary dropdown menu if your funder has different requirements for specific programs (e.g., NSF, DOE). See the complete list of <a href="https://dmptool.org/public_templates\" target="_blank">funder requirements</a> supported by DMPTool. If your funder is not in the list or you are not applying for a grant, check the box for “No funder associated with this plan;” this selection will provide you with a generic template.</li></ol>
+<%= raw _('<ol type="1"><li>Enter a title for your research project. If applying for funding, use the project title as it appears in the proposal.</li><li>Select the primary research organization. If you are associated with a participating institution/organization, this field will be pre-populated. You have the option to clear the field and select another organization from the list. Based on your selection, you will be presented with institution-specific templates and guidance. You can also check the box that “No organization is associated with this plan.”</li><li>Select the primary funding organization. If you are required to include a data management plan as part of a grant proposal, select your funder from the list. You may be presented with a secondary dropdown menu if your funder has different requirements for specific programs (e.g., NSF, DOE). See the complete list of <a href="https://dmptool.org/public_templates\">funder requirements</a> supported by DMPTool. If your funder is not in the list or you are not applying for a grant, check the box for “No funder associated with this plan;” this selection will provide you with a generic template.</li></ol>') %>
 
-If you are just testing the tool or taking a course on data management, check the box “Mock project for test, practice, or educational purposes.” Marking your plans as a test will be reflected in usage statistics and prevent public or organizational sharing; this allows other users to find real sample plans more easily. 
+<%= _('If you are just testing the tool or taking a course on data management, check the box “Mock project for test, practice, or educational purposes.” Marking your plans as a test will be reflected in usage statistics and prevent public or organizational sharing; this allows other users to find real sample plans more easily.') %>
 
-Once you have made your selections, click “Create plan.”
+<%= _('Once you have made your selections, click “Create plan.”') %>
 
-You can also make a copy of an existing plan (from the Actions menu next to the plan on My dashboard) and update it for a new research project and/or grant proposal.
+<%= _('You can also make a copy of an existing plan (from the Actions menu next to the plan on My dashboard) and update it for a new research project and/or grant proposal.') %>
 <br>
 
-<h4>Write your plan</h4>
+<h4><%= _('Write your plan') %></h4>
 
-The tabbed interface allows you to navigate through different functions when editing your plan.   
-<ul>
-<li>“Project details” includes basic administrative details. The right-hand side of the page is where you can select up to 6 organizations to view additional guidance as you write your plan. The more information you provide here, the more useful your plan will be to you and others in the future (e.g., for data reuse and proper attribution). On the Edit profile page you can create or connect your ORCID iD; this is required by some funders and a growing list of publishers (Learn more at <a href="https://orcid.org\" target="_blank">orcid.org</a>).</li>
-<li>“Plan overview” provides an overview of the questions that you will be asked.
-The following tab(s) present the questions to answer. There may be more than one tab if your funder or institution asks different sets of questions at different stages, e.g., at grant application and post-award. Guidance and comments are displayed in the right-hand panel beside each question. If you need more guidance or find there is too much, you can make adjustments on the “Project details” tab.</li> 
-<li>“Share” allows you to invite others to contribute to or comment on your plan. This is also where you can set your plan visibility (details below).</li>
-<li>“Download” allows you to download your plan in various formats. You can adjust the formatting (font type, size, and margins) for PDF files, which may be helpful if working to page limits (e.g., NSF data management plans are limited to 2 pages).</li></ul>
+<%= raw _('The tabbed interface allows you to navigate through different functions when editing your plan.<ul><li>“Project details” includes basic administrative details. The right-hand side of the page is where you can select up to 6 organizations to view additional guidance as you write your plan. The more information you provide here, the more useful your plan will be to you and others in the future (e.g., for data reuse and proper attribution). On the Edit profile page you can create or connect your ORCID iD; this is required by some funders and a growing list of publishers (Learn more at <a href="https://orcid.org\">orcid.org</a>).</li><li>“Plan overview” provides an overview of the questions that you will be asked. The following tab(s) present the questions to answer. There may be more than one tab if your funder or institution asks different sets of questions at different stages, e.g., at grant application and post-award. Guidance and comments are displayed in the right-hand panel beside each question. If you need more guidance or find there is too much, you can make adjustments on the “Project details” tab.</li><li>“Share” allows you to invite others to contribute to or comment on your plan. This is also where you can set your plan visibility (details below).</li><li>“Download” allows you to download your plan in various formats. You can adjust the formatting (font type, size, and margins) for PDF files, which may be helpful if working to page limits (e.g., NSF data management plans are limited to 2 pages).</li></ul>') %>
 <br>
 
-<h4>Share plans</h4>
+<h4><%= _('Share plans') %></h4>
 
-Input the email address(es) of any collaborators you would like to invite to read or edit your plan. Set their permissions via the radio buttons and click to 'Add collaborator.' Adjust permissions or remove collaborators at any time via the drop-down options in the table.
+<%= _('Input the email address(es) of any collaborators you would like to invite to read or edit your plan. Set their permissions via the radio buttons and click to "Add collaborator." Adjust permissions or remove collaborators at any time via the drop-down options in the table.') %>
 
-The “Share” tab is also where you can set your plan visibility.
-<ul>
-<li>Private: restricted to you and your collaborators.</li>
-<li>Organizational: anyone at your organization can view your plan.</li>
-<li>Public: anyone can view your plan in the <a href="https://dmptool.org/public_plans\" target="_blank">public plans</a> list.</li></ul>
+<%= raw _('The "Share" tab is also where you can set your plan visibility.<ul><li>Private: restricted to you and your collaborators.</li><li>Organizational: anyone at your organization can view your plan.</li><li>Public: anyone can view your plan in the <a href="https://dmptool.org/public_plans\">public plans</a> list.</li></ul>') %>
 
-By default all new and test plans will be set to Private visibility. Public and Organizational visibility are intended for finished plans. You must answer at least 50% of the questions to enable these options.  
+<%= _('By default all new and test plans will be set to Private visibility. Public and Organizational visibility are intended for finished plans. You must answer at least 50% of the questions to enable these options.') %>
 
 <img src="https://github.com/CDLUC3/dmptool/blob/master/docs/quickstartguide/share-tab-ai.png?raw=true" alt="Share tab" style="width: 80%; margin-left: 45px;" />
 <hr> 
 
-<h3 id="how-do-i-get-help-from-someone-at-my-institution">How do I get help from someone at my institution?</h3>
+<h3 id="how-do-i-get-help-from-someone-at-my-institution"><%= _('How do I get help from someone at my institution?') %></h3>
 
-After logging in, you will find an email address and URL for help at the top of the page.   
+<%= _('After logging in, you will find an email address and URL for help at the top of the page.') %>
  
-There may also be an option to request feedback on your plan (on the “Share” tab). This is available when research support staff at your institution have enabled the service. Click to “Request feedback” and your local administrators will be alerted to your request. Their comments will be visible in the “Comments” field adjacent to each question. You will receive an email notification when an administrator provides feedback. 
+<%= _('There may also be an option to request feedback on your plan (on the “Share” tab). This is available when research support staff at your institution have enabled the service. Click to “Request feedback” and your local administrators will be alerted to your request. Their comments will be visible in the “Comments” field adjacent to each question. You will receive an email notification when an administrator provides feedback.') %>
 

--- a/app/views/static_pages/promote.html.md
+++ b/app/views/static_pages/promote.html.md
@@ -1,47 +1,28 @@
-<h1>Promote the DMPTool</h1>
+<h1><%= _('Promote the DMPTool') %></h1>
 <hr>
 
-Help spread the word about the DMPTool! Use the materials below to inform researchers, librarians, administrators and others about the tool. All materials are available under a CC-Zero license.
+<%= _('Help spread the word about the DMPTool! Use the materials below to inform researchers, librarians, administrators and others about the tool. All materials are available under a CC-Zero license.') %>
 <br>
-<h3>DMPTool logo</h3>
-
-<ul>
-<li>DMPTool Logo (blue), with tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.eps" target=\"_blank\">EPS</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.svg" target=\"_blank\">SVG</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.png" target=\"_blank\">PNG</a></li>      
-<li>DMPTool Logo (blue), no tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.eps" target=\"_blank\">EPS</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.svg" target=\"_blank\">SVG</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.png" target=\"_blank\">PNG</a></li>   
-<li>DMPTool Logo (green v2), with tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v2.png" target=\"_blank\">PNG</a></li>   
-<li>DMPTool Logo (green v2), no tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v2_no_tag.png" target=\"_blank\">PNG</a></li>   
-<li>Original DMPTool Logo - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v1.png" target=\"_blank\">PNG</a></li></ul>   
+<h3><%= _('DMPTool logo') %></h3>
+<%= raw _('<ul><li>DMPTool Logo (blue), with tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.eps">EPS</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.svg">SVG</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue.png">PNG</a></li><li>DMPTool Logo (blue), no tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.eps">EPS</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.svg">SVG</a>, <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_blue_no_tag.png">PNG</a></li><li>DMPTool Logo (green v2), with tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v2.png">PNG</a></li><li>DMPTool Logo (green v2), no tagline - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v2_no_tag.png">PNG</a></li><li>Original DMPTool Logo - <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/logos/DMPTool_logo_v1.png">PNG</a></li></ul>') %>
 <br>
 
-<h3>Postcards - new versions coming soon!</h3>
+<h3><%= _('Postcards - new versions coming soon!') %></h3>
 
-Advertise the DMPTool to students and researchers at your institution.    
-<ul>
-<li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/postcard/DMPTool_postcard_v2.pdf" target=\"_blank\">Adobe PDF</a> </li></ul>
+<%= raw _('Advertise the DMPTool to students and researchers at your institution.<ul><li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/postcard/DMPTool_postcard_v2.pdf">Adobe PDF</a></li></ul>') %>
   
 <br>
 
-<h3>Poster - new version coming soon!</h3>
+<h3><%= _('Poster - new version coming soon!') %></h3>
 
-Use this conference-style poster to advertise the DMPTool at events on your campus.   
-<ul>
-<li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/poster/DMPTool_poster_v2.pdf" target=\"_blank\">Adobe PDF</a>
-  <br></li></ul>
+<%= raw _('Use this conference-style poster to advertise the DMPTool at events on your campus.<ul><li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/poster/DMPTool_poster_v2.pdf">Adobe PDF</a></li></ul>') %>
 
-<h3>Talking points</h3>
+<h3><%= _('Talking points') %></h3>
 
-Need to get others on your campus interested in the DMPTool? Use our Talking Points to guide your discussions. In general, a talking points document is designed to help you stay on track during meetings with those outside of your department. It ensures that your major points are at hand and helps you make progress towards the goals of the meeting.   
-
-<ul>
-<li>Overview of Talking Points: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/overview.pdf" target=\"_blank\">Adobe PDF</a></li>   
-<li>Meeting with your IT Group: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/IT.docx" target=\"_blank\">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/IT.pdf" target=\"_blank\">Adobe PDF</a></li>   
-<li>Meeting with Administrators: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/admin.docx" target=\"_blank\">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/admin.pdf" target=\"_blank\">Adobe PDF</a></li>   
-<li>Meeting with Researchers: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/researchers.docx" target=\"_blank\">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/researchers.pdf" target=\"_blank\">Adobe PDF</a> </li></ul>  
+<%= raw _('Need to get others on your campus interested in the DMPTool? Use our Talking Points to guide your discussions. In general, a talking points document is designed to help you stay on track during meetings with those outside of your department. It ensures that your major points are at hand and helps you make progress towards the goals of the meeting.<ul><li>Overview of Talking Points: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/overview.pdf">Adobe PDF</a></li><li>Meeting with your IT Group: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/IT.docx">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/IT.pdf">Adobe PDF</a></li><li>Meeting with Administrators: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/admin.docx">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/admin.pdf">Adobe PDF</a></li><li>Meeting with Researchers: <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/researchers.docx">Microsoft Word</a> or <a href="https://github.com/CDLUC3/dmptool/blob/master/docs/talkpoints/researchers.pdf">Adobe PDF</a> </li></ul>') %>
 
 <br>
-<h3>General purpose slides - updated slides coming soon!</h3>
+<h3><%= _('General purpose slides - updated slides coming soon!') %></h3>
 
-We created a generic slide deck that you can use to introduce researchers and others to the DMPTool.   
-<ul>
-<li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/genericslides/DMPT2_GenericSlides.pptx" target=\"_blank\">Microsoft Powerpoint</a> </li></ul>  
+<%= raw _('We created a generic slide deck that you can use to introduce researchers and others to the DMPTool.<ul><li><a href="https://github.com/CDLUC3/dmptool/blob/master/docs/genericslides/DMPT2_GenericSlides.pptx">Microsoft Powerpoint</a> </li></ul>') %>
 

--- a/app/views/static_pages/termsuse.html.md
+++ b/app/views/static_pages/termsuse.html.md
@@ -2,11 +2,11 @@
 
 <hr>
 
-<%= raw _('The <a href="http://www.cldib.org" target="_blank">California Digital Library (CDL)</a> is supported by the University of California (UC). Our primary constituency is the UC research community; in addition, we provide services to the United States and international higher education sector.') %>
+<%= raw _('The <a href="http://www.cldib.org">California Digital Library (CDL)</a> is supported by the University of California (UC). Our primary constituency is the UC research community; in addition, we provide services to the United States and international higher education sector.') %>
 <br>
 <h4><%= _('DMPTool') %></h4>
 
-<%= raw _("DMPTool ('the tool', 'the system') is a tool developed by the CDL and the <a href=\"http://www.dcc.ac.uk/\" target=\"_blank\">Digital Curation Centre (DCC)</a> as a shared resource for the research community. It is hosted at CDL by the University of California Curation Center (UC3).") %>
+<%= raw _("DMPTool ('the tool', 'the system') is a tool developed by the CDL and the <a href=\"http://www.dcc.ac.uk/\">Digital Curation Centre (DCC)</a> as a shared resource for the research community. It is hosted at CDL by the University of California Curation Center (UC3).") %>
 <br>
 
 <h4><%= _('Your personal details') %></h4>
@@ -16,7 +16,7 @@
 
 <h4><%= _('Privacy policy') %></h4>
 
-<%= raw _('The information you enter into this system can be seen by you, people you have chosen to share access with, and—solely for the purposes of maintaining the service—system administrators at the CDL. We compile anonymized, automated, and aggregated information from plans, but we will not directly access, make use of, or share your content with anyone beyond CDL and your home institution without your permission. Authorized users at your home institution may access your plans for specific purposes—for example, to track compliance with funder/institutional requirements, to calculate storage requirements, or to assess demand for data management services across disciplines. For a detailed description of what information (other than the plans) we collect from visitors to this website and how it is used and managed, please see the CDL Privacy Policy and Baseline Supporting Practices listed at <a href="http://www.cdlib.org/about/policies.html" target="blank">http://www.cdlib.org/about/policies.html</a>') %>
+<%= raw _('The information you enter into this system can be seen by you, people you have chosen to share access with, and—solely for the purposes of maintaining the service—system administrators at the CDL. We compile anonymized, automated, and aggregated information from plans, but we will not directly access, make use of, or share your content with anyone beyond CDL and your home institution without your permission. Authorized users at your home institution may access your plans for specific purposes—for example, to track compliance with funder/institutional requirements, to calculate storage requirements, or to assess demand for data management services across disciplines. For a detailed description of what information (other than the plans) we collect from visitors to this website and how it is used and managed, please see the CDL Privacy Policy and Baseline Supporting Practices listed at <a href="http://www.cdlib.org/about/policies.html">http://www.cdlib.org/about/policies.html</a>') %>
 <br>
 
 <h4><%= _('Freedom of Information') %></h4>
@@ -31,7 +31,7 @@
 
 <h4><%= _('Google Analytics opt-out') %></h4>
 
-<%= raw _('As noted in the CDL privacy policy, this website uses Google Analytics to capture and analyze usage statistics. You may choose to opt-out of having your website activity tracked by Google Analytics. To do so, visit the <a target="_blank" href="https://tools.google.com/dlpage/gaoptout">Google Analytics opt-out page</a> and install the add-on for your browser.') %>
+<%= raw _('As noted in the CDL privacy policy, this website uses Google Analytics to capture and analyze usage statistics. You may choose to opt-out of having your website activity tracked by Google Analytics. To do so, visit the <a href="https://tools.google.com/dlpage/gaoptout">Google Analytics opt-out page</a> and install the add-on for your browser.') %>
 <br>
 
 <h4><%= _('Third party APIs') %></h4>

--- a/app/views/user_mailer/feedback_complete.html.erb
+++ b/app/views/user_mailer/feedback_complete.html.erb
@@ -6,6 +6,6 @@
 %>
 
 <p><%= _('Hello %{recipient_name}') % { recipient_name: recipient_name } %></p>
-<p><%= _('%{commenter} has finished providing feedback on the plan “%{plan_title}”. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan.') % { commenter: requestor, plan_title: plan_name, tool_name: tool_name } %></p>
+<p><%= _('%{commenter} has finished providing feedback on the plan "%{plan_title}". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan.') % { commenter: requestor, plan_title: plan_name, tool_name: tool_name } %></p>
 
 <%= render partial: 'email_signature' %>


### PR DESCRIPTION
- Fixed issue when trying to create an account for an email address that already existed
- Fixed request feedback emails so that the commenter and plan owner names are correct
- Fixed issue with plan content appearing twice in DOCX downloads
- Fixed issue encountered when downloading plans with blank answers
- Fixed issue on super admin organization page
- Updated Help, Promote, and Terms pages so that they are translatable