### PR TITLE
Added json export to download page

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -44,6 +44,7 @@ class PlanExportsController < ApplicationController
       format.text { show_text }
       format.docx { show_docx }
       format.pdf  { show_pdf }
+      format.json { show_json }
     end
   end
 
@@ -87,6 +88,11 @@ class PlanExportsController < ApplicationController
              right:     "[page] of [topage]",
              encoding: "utf8"
            }
+  end
+
+  def show_json
+    json = render_to_string(partial: "/api/v1/plans/show", locals: { plan: @plan })
+    render json: "{\"dmp\":#{json}}"
   end
 
   def file_name

--- a/app/javascript/views/plans/download.js
+++ b/app/javascript/views/plans/download.js
@@ -2,16 +2,24 @@ $(() => {
   // Add a target="_blank" to the form when PDF or HTML are selected
   // Hide the PDF Formatting section if 'pdf' is not the desired format
   $('#download_form select#format').on('change', (e) => {
-    if ($(e.currentTarget).val() === 'pdf' || $(e.currentTarget).val() === 'html') {
+    const frmt = $(e.currentTarget).val();
+
+    if (frmt === 'pdf' || frmt === 'html' || frmt === 'json') {
       $('#download_form').attr('target', '_blank');
     } else {
       $('#download_form').removeAttr('target');
     }
 
-    if ($(e.currentTarget).val() === 'pdf') {
+    if (frmt === 'pdf') {
       $('#pdf-formatting').show();
     } else {
       $('#pdf-formatting').hide();
+    }
+
+    if (frmt === 'json') {
+      $('#download-settings').hide();
+    } else {
+      $('#download-settings').show();
     }
   });
 });

--- a/app/models/settings/template.rb
+++ b/app/models/settings/template.rb
@@ -25,7 +25,7 @@ module Settings
     VALID_ADMIN_FIELDS = ['project_name', 'project_identifier', 'grant_title', 'principal_investigator',
                           'project_data_contact', 'project_description', 'funder', 'institution', 'orcid']
 
-    VALID_FORMATS = ['csv', 'html', 'pdf', 'text', 'docx']
+    VALID_FORMATS = %w[csv html pdf text docx json].freeze
 
     # =================================
     # Start DMPTool Customization

--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -6,45 +6,6 @@
 <% end %>
 
 <%= form_tag(plan_export_path(@plan), method: :get, target: '_blank', id: 'download_form') do |f| %>
-  <h2><%= _("Download settings") %></h2>
-  <%= hidden_field_tag 'export[form]', true %>
-  <% if @phase_options.length > 1 %>
-    <div class="form-group">
-      <%= label_tag(:phase_id, _("Select phase to download")) %>
-      <%= select_tag(:phase_id, options_for_select(@phase_options, @phase_options[0])) %>
-    </div>
-  <% else %>
-    <%= hidden_field_tag(:phase_id, @phase_options[0][1]) %>
-  <% end %>
-  <fieldset>
-    <legend><%= _("Optional plan components") %></legend>
-    <div class="checkbox">
-      <%= label_tag 'export[project_details]' do %>
-        <%= check_box_tag 'export[project_details]', true, false %>
-        <%= _('project details coversheet') %>
-      <% end %>
-    </div>
-    <div class="checkbox">
-      <%= label_tag 'export[question_headings]' do %>
-        <%= check_box_tag 'export[question_headings]', true, true %>
-        <%= _('question text and section headings') %>
-      <% end %>
-    </div>
-    <div class="checkbox">
-      <%= label_tag 'export[unanswered_questions]' do %>
-        <%= check_box_tag 'export[unanswered_questions]', true, true %>
-        <%= _('unanswered questions') %>
-      <% end %>
-    </div>
-    <% if @plan.template.customization_of.present? %>
-      <div class="checkbox">
-        <%= label_tag 'export[custom_sections]' do %>
-          <%= check_box_tag 'export[custom_sections]', true, false %>
-          <%= _('supplementary section(s) not requested by funding organisation') %>
-        <% end %>
-      </div>
-    <% end %>
-  </fieldset>
 
   <h2><%= _('Format') %></h2>
   <div class="row">
@@ -52,6 +13,48 @@
       <%= select_tag :format, options_for_select(Settings::Template::VALID_FORMATS, :pdf),
                      class: 'form-control', "aria-labelledby": "format" %>
     </div>
+  </div>
+
+  <div id="download-settings">
+    <h2><%= _("Download settings") %></h2>
+    <%= hidden_field_tag 'export[form]', true %>
+    <% if @phase_options.length > 1 %>
+      <div class="form-group">
+        <%= label_tag(:phase_id, _("Select phase to download")) %>
+        <%= select_tag(:phase_id, options_for_select(@phase_options, @phase_options[0])) %>
+      </div>
+    <% else %>
+      <%= hidden_field_tag(:phase_id, @phase_options[0][1]) %>
+    <% end %>
+    <fieldset>
+      <legend><%= _("Optional plan components") %></legend>
+      <div class="checkbox">
+        <%= label_tag 'export[project_details]' do %>
+          <%= check_box_tag 'export[project_details]', true, false %>
+          <%= _('project details coversheet') %>
+        <% end %>
+      </div>
+      <div class="checkbox">
+        <%= label_tag 'export[question_headings]' do %>
+          <%= check_box_tag 'export[question_headings]', true, true %>
+          <%= _('question text and section headings') %>
+        <% end %>
+      </div>
+      <div class="checkbox">
+        <%= label_tag 'export[unanswered_questions]' do %>
+          <%= check_box_tag 'export[unanswered_questions]', true, true %>
+          <%= _('unanswered questions') %>
+        <% end %>
+      </div>
+      <% if @plan.template.customization_of.present? %>
+        <div class="checkbox">
+          <%= label_tag 'export[custom_sections]' do %>
+            <%= check_box_tag 'export[custom_sections]', true, false %>
+            <%= _('supplementary section(s) not requested by funding organisation') %>
+          <% end %>
+        </div>
+      <% end %>
+    </fieldset>
   </div>
 
   <div id="pdf-formatting">


### PR DESCRIPTION
Fixes #2438
Allows a user to download the API v1 version of their DMP from the Download page.

- Add JSON as an export type
- Wrap 'Download Settings' in a div so that it can be hidden when JSON is selected
- Swapped position of format dropdown and Download Settings checkboxes