### PR TITLE
Apiv2 template question annotations and question_options

### DIFF
--- a/app/views/api/v2/annotations/_show.json.jbuilder
+++ b/app/views/api/v2/annotations/_show.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# locals: annotation
+
+json.text annotation.text
+json.type annotation.type
+json.created annotation.created_at.to_formatted_s(:iso8601)
+json.modified annotation.updated_at.to_formatted_s(:iso8601)
+json.question_id annotation.question_id
+json.org_id annotation.org_id

--- a/app/views/api/v2/question_options/_show.json.jbuilder
+++ b/app/views/api/v2/question_options/_show.json.jbuilder
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# locals: question_option
+
+json.is_default question_option.is_default
+json.number question_option.number
+json.text question_option.text
+json.created question_option.created_at.to_formatted_s(:iso8601)
+json.modified question_option.updated_at.to_formatted_s(:iso8601)
+json.question_id question_option.question_id

--- a/app/views/api/v2/questions/_show.json.jbuilder
+++ b/app/views/api/v2/questions/_show.json.jbuilder
@@ -11,3 +11,11 @@ json.created question.created_at.to_formatted_s(:iso8601)
 json.modified question.updated_at.to_formatted_s(:iso8601)
 json.question_format_id question.question_format_id
 json.option_comment_display question.option_comment_display
+
+json.annotations question.annotations do |annotation|
+  json.partial! 'api/v2/annotations/show', annotation: annotation
+end
+
+json.question_options question.question_options do |question_option|
+  json.partial! 'api/v2/question_options/show', question_option: question_option
+end

--- a/spec/views/api/v2/annotations/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/annotations/_show.json.jbuilder_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'api/v2/annotations/_show.json.jbuilder' do
+  before do
+    @annotation = create(:annotation)
+
+    render partial: 'api/v2/annotations/show', locals: { annotation: @annotation }
+    @json = JSON.parse(rendered).with_indifferent_access
+  end
+
+  describe 'includes all of the annotation attributes' do
+    it 'includes :text' do
+      expect(@json[:text]).to eql(@annotation.text)
+    end
+
+    it 'includes :type' do
+      expect(@json[:type]).to eql(@annotation.type)
+    end
+
+    it 'includes :question_id' do
+      expect(@json[:question_id]).to eql(@annotation.question_id)
+    end
+
+    it 'includes :org_id' do
+      expect(@json[:org_id]).to eql(@annotation.org_id)
+    end
+
+    it 'includes the :created' do
+      expect(@json[:created]).to eql(@annotation.created_at.to_formatted_s(:iso8601))
+    end
+
+    it 'includes the :modified' do
+      expect(@json[:modified]).to eql(@annotation.updated_at.to_formatted_s(:iso8601))
+    end
+  end
+end

--- a/spec/views/api/v2/question_options/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/question_options/_show.json.jbuilder_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'api/v2/question_options/_show.json.jbuilder' do
+  before do
+    @question_option = create(:question_option)
+
+    render partial: 'api/v2/question_options/show', locals: { question_option: @question_option }
+    @json = JSON.parse(rendered).with_indifferent_access
+  end
+
+  describe 'includes all of the question_option attributes' do
+    it 'includes :is_default' do
+      expect(@json[:is_default]).to eql(@question_option.is_default)
+    end
+
+    it 'includes :number' do
+      expect(@json[:number]).to eql(@question_option.number)
+    end
+
+    it 'includes :text' do
+      expect(@json[:text]).to eql(@question_option.text)
+    end
+
+    it 'includes the :created' do
+      expect(@json[:created]).to eql(@question_option.created_at.to_formatted_s(:iso8601))
+    end
+
+    it 'includes the :modified' do
+      expect(@json[:modified]).to eql(@question_option.updated_at.to_formatted_s(:iso8601))
+    end
+
+    it 'includes :question_id' do
+      expect(@json[:question_id]).to eql(@question_option.question_id)
+    end
+  end
+end

--- a/spec/views/api/v2/questions/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v2/questions/_show.json.jbuilder_spec.rb
@@ -5,12 +5,11 @@ require 'rails_helper'
 describe 'api/v2/questions/_show.json.jbuilder' do
   before do
     @question = create(:question)
-
     render partial: 'api/v2/questions/show', locals: { question: @question }
     @json = JSON.parse(rendered).with_indifferent_access
   end
 
-  describe 'includes all of the section attributes' do
+  describe 'includes all of the question attributes' do
     it 'includes :default_value' do
       expect(@json[:default_value]).to eql(@question.default_value)
     end
@@ -45,6 +44,14 @@ describe 'api/v2/questions/_show.json.jbuilder' do
 
     it 'includes the :modified' do
       expect(@json[:modified]).to eql(@question.updated_at.to_formatted_s(:iso8601))
+    end
+
+    it 'not includes the :annotations' do
+      expect(@json[:annotations].length).to be(0)
+    end
+
+    it 'not includes the :question_options' do
+      expect(@json[:question_options].length).to be(0)
     end
   end
 end


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- add "annotations" to the template payload when show_phases=true
- add "question_options" to the template payload when show_phases=true

Basically, I need the "example answers" and question options (if non textarea) for a more complete view/payload of the template
