### PR TITLE
convert research_outputs.output_type (Int) to research_outputs.resear…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## DMPTool Releases
 
+### v4.1.0
+**Note: This version includes a change to the research_outputs table!** We have added a new `research_outputs.research_output_type` field that stores a string value. It is a replacement for the old `research_outputs.output_type` integer field. You will need to run: `bin/rails db:migrate && bin/rails v4:upgrade_4_1_0` to make the change to your data model and migrate your existing data to the new field.
+
+- Added column `research_output_type` to the `research_outputs` table
+- Added `v4:upgrade_4_1_0` rake task to migrate data from `output_type` and `output_type_description` to the new `research_output_type` field
+- Updated the ResearchOutput model (and RSpec factory and tests) to use new field
+- Replaced the old `output_types` enum on the ResearchOutput model with `DEFAULT_OUTPUT_TYPES` array
+- Updated presenters (and RSpec tests) and controller to work with the new field
+
 ### v4.0.5
 This version includes changes from [DMPRoadmap release v4.0.2](https://github.com/DMPRoadmap/roadmap/releases/tag/v4.0.2) see the release notes for details.
 

--- a/app/controllers/research_outputs_controller.rb
+++ b/app/controllers/research_outputs_controller.rb
@@ -19,7 +19,7 @@ class ResearchOutputsController < ApplicationController
 
   # GET /plans/:plan_id/research_outputs/new
   def new
-    @research_output = ResearchOutput.new(plan_id: @plan.id, output_type: '')
+    @research_output = ResearchOutput.new(plan_id: @plan.id, research_output_type: '')
     authorize @research_output
   end
 
@@ -88,7 +88,7 @@ class ResearchOutputsController < ApplicationController
   def select_output_type
     @plan = Plan.find_by(id: params[:plan_id])
     @research_output = ResearchOutput.new(
-      plan: @plan, output_type: output_params[:output_type]
+      plan: @plan, research_output_type: output_params[:research_output_type]
     )
     authorize @research_output
   end
@@ -148,7 +148,7 @@ class ResearchOutputsController < ApplicationController
 
   def output_params
     params.require(:research_output)
-          .permit(%i[title abbreviation description output_type output_type_description
+          .permit(%i[title abbreviation description research_output_type
                      sensitive_data personal_data file_size file_size_unit mime_type_id
                      release_date access coverage_start coverage_end coverage_region
                      mandatory_attribution license_id],
@@ -190,8 +190,8 @@ class ResearchOutputsController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize
 
-  # There are certain fields on the form that are visible based on the selected output_type. If the
-  # ResearchOutput previously had a value for any of these and the output_type then changed making
+  # There are certain fields on the form that are visible based on the selected research_output_type. If the
+  # ResearchOutput previously had a value for any of these and the research_output_type then changed making
   # one of these arguments invisible, then we need to blank it out here since the Rails form will
   # not send us the value
   def process_nillable_values(args:)

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -21,6 +21,7 @@
 #  updated_at              :datetime         not null
 #  license_id              :bigint
 #  plan_id                 :integer
+#  research_outputs        :string
 #
 # Indexes
 #
@@ -37,6 +38,10 @@
 class ResearchOutput < ApplicationRecord
   include Identifiable
   include ValidationMessages
+
+  DEFAULT_OUTPUT_TYPES = %w[audiovisual collection data_paper dataset event image interactive_resource
+                            model_representation physical_object service software sound text workflow
+                            other]
 
   enum output_type: { audiovisual: 0, collection: 1, data_paper: 2, dataset: 3, event: 4, image: 5,
                       interactive_resource: 6, model_representation: 7, physical_object: 8,
@@ -58,7 +63,7 @@ class ResearchOutput < ApplicationRecord
   # = Validations =
   # ===============
 
-  validates :output_type, :access, :title, presence: { message: PRESENCE_MESSAGE }
+  validates :research_output_type, :access, :title, presence: { message: PRESENCE_MESSAGE }
   validates :title, uniqueness: { case_sensitive: false, scope: :plan_id,
                                   message: UNIQUENESS_MESSAGE }
   validates :abbreviation, uniqueness: { case_sensitive: false, scope: :plan_id,
@@ -68,8 +73,9 @@ class ResearchOutput < ApplicationRecord
   validates_numericality_of :byte_size, greater_than: 0, less_than_or_equal_to: 2**63,
                                         allow_blank: true,
                                         message: '(Anticipated file size) is too large. Please enter a smaller value.'
+
   # Ensure presence of the :output_type_description if the user selected 'other'
-  validates :output_type_description, presence: { if: -> { other? }, message: PRESENCE_MESSAGE }
+  validates :output_type_description, presence: { if: -> { research_output_type == 'other' }, message: PRESENCE_MESSAGE }
 
   # ====================
   # = Instance methods =

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -40,8 +40,7 @@ class ResearchOutput < ApplicationRecord
   include ValidationMessages
 
   DEFAULT_OUTPUT_TYPES = %w[audiovisual collection data_paper dataset event image interactive_resource
-                            model_representation physical_object service software sound text workflow
-                            other]
+                            model_representation physical_object service software sound text workflow]
 
   enum output_type: { audiovisual: 0, collection: 1, data_paper: 2, dataset: 3, event: 4, image: 5,
                       interactive_resource: 6, model_representation: 7, physical_object: 8,
@@ -73,9 +72,6 @@ class ResearchOutput < ApplicationRecord
   validates_numericality_of :byte_size, greater_than: 0, less_than_or_equal_to: 2**63,
                                         allow_blank: true,
                                         message: '(Anticipated file size) is too large. Please enter a smaller value.'
-
-  # Ensure presence of the :output_type_description if the user selected 'other'
-  validates :output_type_description, presence: { if: -> { research_output_type == 'other' }, message: PRESENCE_MESSAGE }
 
   # ====================
   # = Instance methods =

--- a/app/presenters/api/v1/research_output_presenter.rb
+++ b/app/presenters/api/v1/research_output_presenter.rb
@@ -5,7 +5,8 @@ module Api
     # Helper methods for research outputs
     class ResearchOutputPresenter
       attr_reader :dataset_id, :preservation_statement, :security_and_privacy, :license_start_date,
-                  :data_quality_assurance, :distributions, :metadata, :technical_resources
+                  :data_quality_assurance, :distributions, :metadata, :technical_resources,
+                  :research_output_type
 
       def initialize(output:)
         @research_output = output
@@ -13,6 +14,11 @@ module Api
 
         @plan = output.plan
         @dataset_id = identifier
+
+        # The DMPHub only recognizes the DEFAULT research_output_types, so use 'other' if these
+        # are custom types added by an admin
+        use_other = !ResearchOutput::DEFAULT_OUTPUT_TYPES.include?(output.research_output_type)
+        @research_output_type = use_other ? 'other' : output.research_output_type
 
         load_narrative_content
 

--- a/app/presenters/research_output_presenter.rb
+++ b/app/presenters/research_output_presenter.rb
@@ -10,8 +10,7 @@ class ResearchOutputPresenter
 
   # Returns the output_type list for a select_tag
   def selectable_output_types
-    ResearchOutput.output_types
-                  .map { |k, _v| [k.humanize, k] }
+    ResearchOutput::DEFAULT_OUTPUT_TYPES.map { |k| [k.humanize, k] }
   end
 
   # Returns the access options for a select tag
@@ -109,9 +108,9 @@ class ResearchOutputPresenter
   def display_type
     return '' unless @research_output.is_a?(ResearchOutput)
     # Return the user entered text for the type if they selected 'other'
-    return @research_output.output_type_description if @research_output.other?
+    return @research_output.output_type_description if @research_output.research_output_type == 'other'
 
-    @research_output.output_type.gsub('_', ' ').capitalize
+    @research_output.research_output_type.humanize.capitalize
   end
 
   # Returns the display name(s) of the repository(ies)

--- a/app/presenters/research_output_presenter.rb
+++ b/app/presenters/research_output_presenter.rb
@@ -107,8 +107,6 @@ class ResearchOutputPresenter
   # Returns the humanized version of the output_type enum variable
   def display_type
     return '' unless @research_output.is_a?(ResearchOutput)
-    # Return the user entered text for the type if they selected 'other'
-    return @research_output.output_type_description if @research_output.research_output_type == 'other'
 
     @research_output.research_output_type.humanize.capitalize
   end

--- a/app/views/api/v1/datasets/_show.json.jbuilder
+++ b/app/views/api/v1/datasets/_show.json.jbuilder
@@ -5,7 +5,7 @@
 if output.is_a?(ResearchOutput)
   presenter = Api::V1::ResearchOutputPresenter.new(output: output)
 
-  json.type output.output_type
+  json.type presenter.research_output_type
   json.title output.title
   json.description output.description
   json.personal_data Api::V1::ApiPresenter.boolean_to_yes_no_unknown(value: output.personal_data)

--- a/app/views/api/v2/datasets/_show.json.jbuilder
+++ b/app/views/api/v2/datasets/_show.json.jbuilder
@@ -5,7 +5,7 @@
 if output.is_a?(ResearchOutput)
   presenter = Api::V1::ResearchOutputPresenter.new(output: output)
 
-  json.type output.output_type
+  json.type presenter.research_output_type
   json.title output.title
   json.description output.description
   json.personal_data Api::V1::ApiPresenter.boolean_to_yes_no_unknown(value: output.personal_data)

--- a/db/migrate/20230322145714_change_research_outputs_output_type.rb
+++ b/db/migrate/20230322145714_change_research_outputs_output_type.rb
@@ -1,0 +1,5 @@
+class ChangeResearchOutputsOutputType < ActiveRecord::Migration[6.1]
+  def change
+    add_column :research_outputs, :research_output_type, :string, default: 'dataset', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -561,6 +561,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_104737) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "license_id"
+    t.string "research_output_type", default: 'dataset', null: false
     t.index ["license_id"], name: "index_research_outputs_on_license_id"
     t.index ["output_type"], name: "index_research_outputs_on_output_type"
     t.index ["plan_id"], name: "index_research_outputs_on_plan_id"

--- a/lib/tasks/v4.rake
+++ b/lib/tasks/v4.rake
@@ -5,12 +5,17 @@
 
 # rubocop:disable Naming/VariableNumber
 namespace :v4 do
-  desc 'Upgrade from v4.0.8 to v4.0.9'
-  task upgrade_4_0_9: :environment do
+  desc 'Upgrade from v4.0.x to v4.1.0'
+  task upgrade_4_1_0: :environment do
     puts 'Converting the old research_outputs.output_type Integer field (an enum in the model) to a string '
     puts 'value in the new research_outputs.research_output_type field'
 
-    ResearchOutput.all.each { |rec| rec.update(research_output_type: rec.output_type.to_s) }
+    ResearchOutput.all.each do |rec|
+      rec.update(research_output_type: rec.output_type_description) if rec.other?
+      next if rec.other?
+
+      rec.update(research_output_type: rec.output_type.to_s)
+    end
 
     puts 'DONE'
   end

--- a/lib/tasks/v4.rake
+++ b/lib/tasks/v4.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Upgrade tasks for 4.x versions. See https://github.com/DMPRoadmap/roadmap/releases for information
+# on how and when to run each task.
+
+# rubocop:disable Naming/VariableNumber
+namespace :v4 do
+  desc 'Upgrade from v4.0.8 to v4.0.9'
+  task upgrade_4_0_9: :environment do
+    puts 'Converting the old research_outputs.output_type Integer field (an enum in the model) to a string '
+    puts 'value in the new research_outputs.research_output_type field'
+
+    ResearchOutput.all.each { |rec| rec.update(research_output_type: rec.output_type.to_s) }
+
+    puts 'DONE'
+  end
+end

--- a/spec/factories/research_outputs.rb
+++ b/spec/factories/research_outputs.rb
@@ -21,6 +21,7 @@
 #  updated_at              :datetime         not null
 #  license_id              :bigint(8)
 #  plan_id                 :integer
+#  research_outputs        :string
 #
 # Indexes
 #
@@ -37,12 +38,12 @@ FactoryBot.define do
     description             { Faker::Lorem.paragraph }
     is_default              { [nil, true, false].sample }
     display_order           { Faker::Number.between(from: 1, to: 20) }
-    output_type             { ResearchOutput.output_types.keys.sample }
     output_type_description { Faker::Lorem.sentence }
     personal_data           { [nil, true, false].sample }
     release_date            { 1.month.from_now }
     sensitive_data          { [nil, true, false].sample }
     title                   { Faker::Music::PearlJam.unique.song }
+    research_output_type    { ResearchOutput::DEFAULT_OUTPUT_TYPES.sample }
 
     transient do
       repositories_count { 1 }

--- a/spec/factories/research_outputs.rb
+++ b/spec/factories/research_outputs.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
     description             { Faker::Lorem.paragraph }
     is_default              { [nil, true, false].sample }
     display_order           { Faker::Number.between(from: 1, to: 20) }
-    output_type_description { Faker::Lorem.sentence }
     personal_data           { [nil, true, false].sample }
     release_date            { 1.month.from_now }
     sensitive_data          { [nil, true, false].sample }

--- a/spec/models/research_output_spec.rb
+++ b/spec/models/research_output_spec.rb
@@ -13,9 +13,8 @@ RSpec.describe ResearchOutput do
     end
 
     it { is_expected.to define_enum_for(:access).with_values(described_class.accesses.keys) }
-    it { is_expected.to define_enum_for(:output_type).with_values(described_class.output_types.keys) }
 
-    it { is_expected.to validate_presence_of(:output_type) }
+    it { is_expected.to validate_presence_of(:research_output_type) }
     it { is_expected.to validate_presence_of(:access) }
     it { is_expected.to validate_presence_of(:title) }
 
@@ -31,13 +30,13 @@ RSpec.describe ResearchOutput do
                                                                .with_message('must be unique')
     }
 
-    it "requires :output_type_description if :output_type is 'other'" do
-      @subject.other!
+    it "requires :output_type_description if :research_output_type is 'other'" do
+      @subject.research_output_type = 'other'
       expect(@subject).to validate_presence_of(:output_type_description)
     end
 
-    it "does not require :output_type_description if :output_type is 'dataset'" do
-      @subject.dataset!
+    it "does not require :output_type_description if :research_output_type is 'dataset'" do
+      @subject.research_output_type = 'dataset'
       expect(@subject).not_to validate_presence_of(:output_type_description)
     end
   end

--- a/spec/models/research_output_spec.rb
+++ b/spec/models/research_output_spec.rb
@@ -29,16 +29,6 @@ RSpec.describe ResearchOutput do
                                                                .scoped_to(:plan_id)
                                                                .with_message('must be unique')
     }
-
-    it "requires :output_type_description if :research_output_type is 'other'" do
-      @subject.research_output_type = 'other'
-      expect(@subject).to validate_presence_of(:output_type_description)
-    end
-
-    it "does not require :output_type_description if :research_output_type is 'dataset'" do
-      @subject.research_output_type = 'dataset'
-      expect(@subject).not_to validate_presence_of(:output_type_description)
-    end
   end
 
   it 'factory builds a valid model' do

--- a/spec/presenters/research_output_presenter_spec.rb
+++ b/spec/presenters/research_output_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ResearchOutputPresenter do
       expect(sample[0].scan(/^[a-zA-Z\s]*$/).any?).to be(true)
       expect(sample[1].scan(/^[a-z]*$/).any?).to be(true)
       expect(sample[0].underscore).to eql(sample[1])
-      expect(ResearchOutput.output_types[sample[1]].present?).to be(true)
+      expect(ResearchOutput::DEFAULT_OUTPUT_TYPES.include?(sample[1])).to be(true)
     end
   end
 
@@ -109,15 +109,15 @@ RSpec.describe ResearchOutputPresenter do
       expect(presenter.display_type).to eql('')
     end
 
-    it "returns the user's description if the output_type is other" do
-      research_output = build(:research_output, output_type: 'other',
+    it "returns the user's description if the research_output_type is other" do
+      research_output = build(:research_output, research_output_type: 'other',
                                                 output_type_description: 'foo')
       presenter = described_class.new(research_output: research_output)
       expect(presenter.display_type).to eql('foo')
     end
 
-    it 'returns the humanized version of the output_type' do
-      presenter = described_class.new(research_output: build(:research_output, output_type: :image))
+    it 'returns the humanized version of the research_output_type' do
+      presenter = described_class.new(research_output: build(:research_output, research_output_type: 'image'))
       expect(presenter.display_type).to eql('Image')
     end
   end

--- a/spec/presenters/research_output_presenter_spec.rb
+++ b/spec/presenters/research_output_presenter_spec.rb
@@ -109,13 +109,6 @@ RSpec.describe ResearchOutputPresenter do
       expect(presenter.display_type).to eql('')
     end
 
-    it "returns the user's description if the research_output_type is other" do
-      research_output = build(:research_output, research_output_type: 'other',
-                                                output_type_description: 'foo')
-      presenter = described_class.new(research_output: research_output)
-      expect(presenter.display_type).to eql('foo')
-    end
-
     it 'returns the humanized version of the research_output_type' do
       presenter = described_class.new(research_output: build(:research_output, research_output_type: 'image'))
       expect(presenter.display_type).to eql('Image')


### PR DESCRIPTION
Hoping this makes working with the output types easier. 

Adds a new `research_output_type` string column to `research_outputs` that will replace the old enum and integer field `output_type`.

To get it working: 
- run `rails db:migrate`
- manually fix the `db/schema.rb` (from the schema file in this PR) that the migration destroyed
- run `rails v4:upgrade_4_0_9` which will seed the new column based on the current `output_type` value
