### PR TITLE
fix issue with react client post/put to drafts_controller.rb

### DIFF
--- a/app/controllers/api/v3/base_api_controller.rb
+++ b/app/controllers/api/v3/base_api_controller.rb
@@ -149,7 +149,7 @@ module Api
       end
 
       def funding_permitted_params
-        %i[name funding_status] +
+        %i[name funding_status dmproadmap_opportunity_number] +
           [funder_ids: identifier_permitted_params,
            grant_ids: identifier_permitted_params]
       end

--- a/app/controllers/api/v3/dmps_controller.rb
+++ b/app/controllers/api/v3/dmps_controller.rb
@@ -54,14 +54,7 @@ module Api
         authed = user_is_authorized(dmp: dmp)
         render_error(errors: DmpsController::MSG_DMP_UNAUTHORIZED, status: :unauthorized) and return unless authed
 
-puts 'PARAMS:'
-puts dmp_permitted_params.inspect
-
         json = JSON.parse(dmp_permitted_params.to_h.to_json)
-
-puts 'JSON:'
-puts json
-
         result = DmpIdService.update_dmp_id(plan: json)
         render_error(errors: DmpsController::MSG_DMP_ID_UPDATE_FAILED, status: :bad_request) and return if result.nil?
 

--- a/app/controllers/api/v3/drafts_controller.rb
+++ b/app/controllers/api/v3/drafts_controller.rb
@@ -104,7 +104,7 @@ module Api
       private
 
       def dmp_params
-        params.require(:dmp).permit(:narrative, :remove_narrative, dmp_permitted_params)# .to_h
+        params.permit(:narrative, :remove_narrative, dmp_permitted_params)# .to_h
       end
     end
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,6 +14,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       origins localhost
     end
 
-    resource '*', headers: :any, methods: %i[get put post delete]
+    resource '*', headers: :any, methods: %i[get options put post delete]
   end
 end

--- a/react-client/src/api.js
+++ b/react-client/src/api.js
@@ -25,7 +25,7 @@ export class DmpApi {
     // The returned headers object can be customized further if needed by the
     // caller.
     let headers = new Headers();
-    headers.append('Content-Type', "application/x-www-form-urlencoded");
+    // headers.append('Content-Type', "application/x-www-form-urlencoded");
     headers.append('Accept', "application/json");
     return headers;
   }

--- a/react-client/src/pages/plan/new-plan/new.js
+++ b/react-client/src/pages/plan/new-plan/new.js
@@ -21,16 +21,18 @@ function PlanNew() {
 
     formData.forEach((value, key) => (stepData[key] = value));
 
-    const fileResult = await api.getFileDataURL(stepData["project_pdf"]);
+    // const fileResult = await api.getFileDataURL(stepData["project_pdf"]);
+
+    /* body: JSON.stringify({
+      dmp: {
+        title: stepData["project_name"],
+        narrative: fileResult,
+      },
+    }), */
 
     let options = api.getOptions({
       method: "post",
-      body: JSON.stringify({
-        dmp: {
-          title: stepData["project_name"],
-          narrative: fileResult,
-        },
-      }),
+      body: formData,
     });
 
     fetch(api.getPath("/drafts"), options)
@@ -58,8 +60,8 @@ function PlanNew() {
                 label="Project Name"
                 type="text"
                 required="required"
-                name="project_name"
-                id="project_name"
+                name="title"
+                id="title"
                 placeholder="Project Name"
                 help="All or part of the project name/title, e.g. 'Particle Physics'"
                 error=""
@@ -78,7 +80,7 @@ function PlanNew() {
 
                 <div className="dmpui-field-fileinput-group  ">
                   <div className="">
-                    <input name="project_pdf" type="file" />
+                    <input name="narrative" type="file" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Hey @andrewebdev. There were some issues with the way the POST/PUT data was being sent to Rails.

First, the `api.js` had a hard coded header of `Content-Type: application/x-www-form-urlencoded` but the pages were sending JSON. This was causing Rails to not be able to interpret the body correctly. I discovered that we can just exclude that header and Rails will apparently figure it out for us.

I referenced [this article](https://medium.com/@aresnik11/how-to-upload-a-file-on-the-frontend-and-send-it-using-js-to-a-rails-backend-29755afaad06) to figure out what to do on the React side.

Second, Rails controllers have normally expect every form element to include a `name` and `id`. For example `id="plan_title" name="plan[title]"` and then Rails gets these as nested parameters `plan: { title: 'value' }`. I wasn't sure how to structure that properly in React though (I suspect that we might need to encode the name due to the brackets). Since I couldn't get the `dmp[title]` to work, I just removed the need for the top level 'dmp' completely.

Please feel free to modify any of the React JS changes.

- Removed the need for the React client to nest all fields under the top level `dmp` (e.g. send `{ title: 'foo' }` instead of `{ dmp: { title: 'foo' } }`
- Commented out the React client's `Content-Type` header. Rails figures out what is being sent
- Commented out the call to `api.getFileDataURL` in `new.js`. Rails was able to work with the File as it was sent via `formData`
- Updated the `new.js` file so that the form fields match what is being sent back to rails so we can just send `formData`
- Added 'dmproadmap_opportunity_number' to the Rails list of acceptable parameters
- Updated cors config to allow a preflight 'options' request (although I don't think this was necessary)