### PR TITLE
Feature/upload page updates

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -284,6 +284,7 @@ orgs = [
    is_other: false, managed: true},
   {name: 'University of Exampleland',
    abbreviation: 'UOS',
+   v5_pilot: true,
    org_type: 1, links: {"org":[]},
    language: default_language, region: region,
    is_other: false, managed: true}

--- a/react-client/src/models.js
+++ b/react-client/src/models.js
@@ -505,6 +505,14 @@ export class DmpModel extends Model {
     return idStr.replace(/\//g, "_");
   }
 
+  get landingPageUrl() {
+    return this.getData("draft_data.landing_page", null)
+  }
+
+  get narrativeUrl() {
+    return this.getData("draft_data.narrative.url", null);
+  }
+
   get hasFunder() {
     if (this.project.funding.name === "None") return false;
     if (this.project.funding.name && this.funding.funderId) return true;

--- a/react-client/src/pages/dashboard/dashboard.js
+++ b/react-client/src/pages/dashboard/dashboard.js
@@ -9,6 +9,8 @@ import TextInput from "../../components/text-input/textInput.js";
 import LookupField from "../../components/lookup-field.js";
 import Spinner from "../../components/spinner";
 import "./dashboard.scss";
+
+const DMP_ID_REGEX = /\/dmps\/([^/]+\/[^/]+)/
 function Dashboard() {
   const [projects, setProjects] = useState([]);
   const [previewDmp, setPreviewDmp] = useState({});
@@ -182,7 +184,7 @@ function Dashboard() {
                       Project Name
                     </th>
 
-                    <th scope="col" className="table-header-name data-heading text-center">
+                    <th scope="col" className="table-header-name data-heading text-center no-wrap">
                       DMP PDF
                     </th>
 
@@ -207,21 +209,25 @@ function Dashboard() {
                   </tr>
                 </thead>
                 <tbody className="table-body">
-                  {projects.map((dmp) => (
-                    <Fragment key={dmp.id}>
-                      <tr key={dmp.id}>
-                        <td
-                          className="table-data-name table-data-title"
-                          data-colname="title"
-                        >
-                          <Link
-                            title={dmp.title}
-                            to={`/dashboard/dmp/${dmp.id}`}
-                          >
-                            {truncateText(dmp.title, 50)}
-                          </Link>
+                  {projects.map((dmp) => {
 
-                          {/*
+                    const dmpId = dmp.landingPageUrl ? dmp.landingPageUrl.match(DMP_ID_REGEX)[1] || [] : null;
+
+                    return (
+                      <Fragment key={dmp.id}>
+                        <tr key={dmp.id}>
+                          <td
+                            className="table-data-name table-data-title"
+                            data-colname="title"
+                          >
+                            <Link
+                              title={dmp.title}
+                              to={`/dashboard/dmp/${dmp.id}`}
+                            >
+                              {truncateText(dmp.title, 50)}
+                            </Link>
+
+                            {/*
                         <a
                           href="#"
                           title={dmp.title}
@@ -251,91 +257,99 @@ function Dashboard() {
                           </span>
                         </a>
 */}
-                          <div className="d-block table-data-pi">
-                            {dmp.contributors
-                              ? dmp.contributors.items.map((item, index) => (
-                                <Fragment key={index}>
-                                  {item.roles &&
-                                    item.roles.filter(str => str.includes("investigation")) && (
-                                      <span>
-                                        PI: {truncateText(item.name, 80)}
-                                      </span>
-                                    )}
-                                </Fragment>
-                              ))
-                              : ""}
+                            <div className="d-block table-data-pi">
+                              {dmp.contributors
+                                ? dmp.contributors.items.map((item, index) => (
+                                  <Fragment key={index}>
+                                    {item.roles &&
+                                      item.roles.filter(str => str.includes("investigation")) && (
+                                        <span>
+                                          PI: {truncateText(item.name, 80)}
+                                        </span>
+                                      )}
+                                  </Fragment>
+                                ))
+                                : ""}
 
-                            {dmp.id && dmp.id == "XXX" && (
-                              <span className={"action-required-text"}>
-                                X works need verification
+                              {dmp.id && dmp.id == "XXX" && (
+                                <span className={"action-required-text"}>
+                                  X works need verification
+                                </span>
+                              )}
+                            </div>
+                          </td>
+
+                          <td className="table-data-name text-center" data-colname="pdf">
+                            {dmp.narrativeUrl &&
+                              <a target="_blank" className="has-new-window-popup-info" href={dmp.narrativeUrl}>
+                                <i className="fas fa-file-pdf" aria-hidden="true"></i>
+                                <em className="sr-only">(opens as a .pdf document in a new window)</em>
+                                <span className="new-window-popup-info">Opens in a new window</span>
+                              </a>
+                            }
+                          </td>
+
+                          <td className="table-data-name" data-colname="funder">
+                            {dmp.funding.acronym ? (
+                              <span title={dmp.funding.name}>
+                                {dmp.funding.acronym}
                               </span>
+                            ) : dmp.funding.name ? (
+                              <span title={dmp.funding.name}>
+                                {truncateText(dmp.funding.name, 50)}
+                              </span>
+                            ) : (
+                              "None"
                             )}
-                          </div>
-                        </td>
-                        <td className="table-data-name text-center" data-colname="pdf">
-                          <a target="_blank" className="has-new-window-popup-info" href="">
-                            <i className="fas fa-file-pdf" aria-hidden="true"></i>
-                            <em className="sr-only">(opens as a .pdf document in a new window)</em>
-                            <span className="new-window-popup-info">Opens in a new window</span>
-                          </a>
-                        </td>
-                        <td className="table-data-name" data-colname="funder">
-                          {dmp.funding.acronym ? (
-                            <span title={dmp.funding.name}>
-                              {dmp.funding.acronym}
-                            </span>
-                          ) : dmp.funding.name ? (
-                            <span title={dmp.funding.name}>
-                              {truncateText(dmp.funding.name, 50)}
-                            </span>
-                          ) : (
-                            "None"
-                          )}
 
 
-                        </td>
-                        <td
-                          className="table-data-date"
-                          data-colname="last_edited"
-                        >
-                          {dmp?.modified ? dmp?.modified : dmp?.created}
-                        </td>
-                        <td className="table-data-date" data-colname="dmp_id">
-                          <a target="_blank" className="has-new-window-popup-info" href="http://localhost:3000/dmps/10.48321/D1SP4H" title="dmp info">
-                            <em className="sr-only">(opens dmp info in a new window</em>
-                            <span className="new-window-popup-info">Opens in new window</span>
-                          </a>
-                        </td>
-                        <td
-                          className={"table-data-name status-" + dmp.status[0]}
-                          data-colname="status"
-                        >
-                          {dmp.status[1]}
-                        </td>
-                        <td
-                          className="table-data-name table-data-actions"
-                          data-colname="actions"
-                        >
-                          {dmp.status[1] === "Complete" ? (
-                            <Link
-                              className="edit-button"
-                              to={`/dashboard/dmp/${dmp.id}`}
-                            >
-                              Complete
-                            </Link>
-                          ) : (
-                            <Link
-                              className="edit-button"
-                              to={`/dashboard/dmp/${dmp.id}`}
-                            >
-                              Update
-                              <span className={"action-required hidden"}></span>
-                            </Link>
-                          )}
-                        </td>
-                      </tr>
-                    </Fragment>
-                  ))}
+                          </td>
+                          <td
+                            className="table-data-date"
+                            data-colname="last_edited"
+                          >
+                            {dmp?.modified ? dmp?.modified : dmp?.created}
+                          </td>
+                          <td className="table-data-date" data-colname="dmp_id">
+                            {dmp.landingPageUrl &&
+                              <a target="_blank" className="has-new-window-popup-info" href={dmp.landingPageUrl} title="dmp data">
+                                {dmpId}
+                                <em className="sr-only">(opens dmp data in a new window</em>
+                                <span className="new-window-popup-info">Opens in new window</span>
+                              </a>
+                            }
+                          </td>
+                          <td
+                            className={"table-data-name status-" + dmp.status[0]}
+                            data-colname="status"
+                          >
+                            {dmp.status[1]}
+                          </td>
+                          <td
+                            className="table-data-name table-data-actions"
+                            data-colname="actions"
+                          >
+                            {dmp.status[1] === "Complete" ? (
+                              <Link
+                                className="edit-button"
+                                to={`/dashboard/dmp/${dmp.id}`}
+                              >
+                                Complete
+                              </Link>
+                            ) : (
+                              <Link
+                                className="edit-button"
+                                to={`/dashboard/dmp/${dmp.id}`}
+                              >
+                                Update
+                                <span className={"action-required hidden"}></span>
+                              </Link>
+                            )}
+                          </td>
+                        </tr>
+                      </Fragment>
+                    )
+                  })}
                 </tbody>
               </table>
             ) : (

--- a/react-client/src/pages/dashboard/dashboard.js
+++ b/react-client/src/pages/dashboard/dashboard.js
@@ -104,7 +104,8 @@ function Dashboard() {
     <div id="Dashboard">
       <div className="dmpui-heading with-action-button">
         <div>
-          <h1>Uploads</h1>
+          <h1>Pilot Upload Projects</h1>
+          <p>Projects created via the upload of an existing DMP are listed in the table below, including their registration status and DOI (when generated).</p>
         </div>
         <div>
           <button
@@ -181,12 +182,20 @@ function Dashboard() {
                       Project Name
                     </th>
 
+                    <th scope="col" className="table-header-name data-heading text-center">
+                      DMP PDF
+                    </th>
+
                     <th scope="col" className="table-header-name data-heading">
                       Funder
                     </th>
 
                     <th scope="col" className="table-header-name data-heading">
                       Last Edited
+                    </th>
+
+                    <th scope="col" className="table-header-name data-heading">
+                      DMP ID
                     </th>
 
                     <th scope="col" className="table-header-name data-heading">
@@ -263,6 +272,13 @@ function Dashboard() {
                             )}
                           </div>
                         </td>
+                        <td className="table-data-name text-center" data-colname="pdf">
+                          <a target="_blank" className="has-new-window-popup-info" href="">
+                            <i className="fas fa-file-pdf" aria-hidden="true"></i>
+                            <em className="sr-only">(opens as a .pdf document in a new window)</em>
+                            <span className="new-window-popup-info">Opens in a new window</span>
+                          </a>
+                        </td>
                         <td className="table-data-name" data-colname="funder">
                           {dmp.funding.acronym ? (
                             <span title={dmp.funding.name}>
@@ -283,6 +299,12 @@ function Dashboard() {
                           data-colname="last_edited"
                         >
                           {dmp?.modified ? dmp?.modified : dmp?.created}
+                        </td>
+                        <td className="table-data-date" data-colname="dmp_id">
+                          <a target="_blank" className="has-new-window-popup-info" href="http://localhost:3000/dmps/10.48321/D1SP4H" title="dmp info">
+                            <em className="sr-only">(opens dmp info in a new window</em>
+                            <span className="new-window-popup-info">Opens in new window</span>
+                          </a>
                         </td>
                         <td
                           className={"table-data-name status-" + dmp.status[0]}

--- a/react-client/src/pages/dashboard/dashboard.scss
+++ b/react-client/src/pages/dashboard/dashboard.scss
@@ -47,12 +47,14 @@
   display: flex;
   justify-content: space-between;
   margin: 0rem 0 2rem 0;
+
   h5 {
     font-weight: 600 !important;
     margin-top: 0 !important;
     margin-bottom: 0.5rem !important;
   }
 }
+
 .filter-quicklinks {
   display: flex;
   justify-content: space-between;
@@ -62,8 +64,10 @@
     margin-right: 0.5rem;
   }
 }
+
 #Dashboard {
   .dashboard-table {
+
     a:hover,
     a:focus,
     a:active {
@@ -71,12 +75,15 @@
       outline-width: 0;
     }
   }
+
   table thead th {
     background-color: transparent;
   }
+
   table tbody tr:nth-child(2n) {
     background-color: transparent;
   }
+
   td:focus-within,
   td:focus,
   td:hover {
@@ -87,21 +94,25 @@
   .table-container {
     overflow-x: auto;
   }
+
   .table-wrapper {
     width: 100%;
     overflow-x: auto;
   }
 
   .dashboard-table {
-    min-width: 600px; /* adjust this to the minimum width at which you want the table to start scrolling */
+    min-width: 600px;
+    /* adjust this to the minimum width at which you want the table to start scrolling */
 
     min-width: 100%;
     border-collapse: collapse;
     border-spacing: 0;
     border-color: #e2e8f0;
+
     thead tr {
       border-bottom: 1px solid var(--dmpui-brand-blue-900) !important;
     }
+
     tr {
       border-bottom: 1px solid #eee;
     }
@@ -113,6 +124,10 @@
     font-size: 0.875rem;
     font-weight: 700;
     color: var(--dmpui-brand-blue-900);
+  }
+
+  .table-header-name.text-center {
+    text-align: center;
   }
 
   .header-link {
@@ -130,6 +145,7 @@
     background-color: #fff;
     vertical-align: top;
   }
+
   .filter-button {
     padding: 5px 10px;
     font-size: 1rem;
@@ -137,24 +153,29 @@
     border-color: #ddd;
     border-radius: 9px;
   }
+
   .filter-button:hover {
     background-color: #e3e4eb;
   }
+
   .table-data-name {
     padding: 1rem 0.75rem 1rem 1rem;
 
     color: var(--dmpui-brand-blue-900);
   }
+
   .table-data-title a {
     color: var(--dmpui-brand-blue-900);
     font-weight: 400;
   }
+
   .table-data-date {
     padding: 1rem 0.75rem 1rem 1rem;
 
     white-space: nowrap;
     color: var(--dmpui-brand-blue-900);
   }
+
   .table-data-actions a {
     color: var(--dmpui-brand-blue-500) !important;
     text-decoration: underline;
@@ -163,15 +184,22 @@
     text-decoration-thickness: 2px;
     text-decoration-skip-ink: auto;
   }
+
   .table-data-pi {
     margin-top: 5px;
     font-size: 0.8rem;
     color: #585858;
   }
+
   .preview-button {
     margin-left: 8px;
   }
+
+  .fa-file-pdf {
+    font-size: 1.5rem;
+  }
 }
+
 #filter-view,
 #quick-view-view {
   position: fixed;
@@ -187,6 +215,7 @@
   padding: 2rem 2rem;
   transition: all 0.3s ease-in-out;
 }
+
 #filter-modal.show,
 #quick-view-modal.show {
   position: fixed;
@@ -206,7 +235,8 @@
   align-items: center;
   border: none;
   justify-content: center;
-  max-width:none;
+  max-width: none;
+
   #filter-view,
   #quick-view-view {
     opacity: 1;
@@ -224,15 +254,19 @@
     margin-bottom: 0.5rem !important;
   }
 }
+
 .filter-tags {
   margin-bottom: 1rem;
 }
+
 .filter-button {
   position: relative;
 }
+
 .filter-clear-all-button {
   margin-left: 2rem;
 }
+
 @media screen and (min-width: 700px) {
   .filter-clear-all-button {
     margin-left: 2rem;

--- a/react-client/src/pages/dashboard/dashboard.scss
+++ b/react-client/src/pages/dashboard/dashboard.scss
@@ -198,6 +198,10 @@
   .fa-file-pdf {
     font-size: 1.5rem;
   }
+
+  .no-wrap {
+    white-space: nowrap;
+  }
 }
 
 #filter-view,


### PR DESCRIPTION
Fixes # 537

Ticket: https://github.com/orgs/CDLUC3/projects/14/views/3?pane=issue&itemId=56195595

As part of the above ticket, I updated the header on the Uploads page, and added a new paragraph below the page header.

I added new columns to the Projects table called **DMP PDF** and **DMP ID.** The **DMP PDF** column displays a PDF icon, and when clicked, takes the user to the PDF in a new tab. The **DMP ID** column displays the dmpId, and they link to the associated DMP landing page.

Verify:

* You can see the new header text and new paragraph
* You can see the two new columns, in the order displayed on this Figma board: https://www.figma.com/proto/Ei6s57Rls4HAUzkrVn3ptd/DMP-Upload-wireframes?page-id=0%3A1&type=design&node-id=217-107&viewport=-3691%2C-30293%2C0.83&t=oWum888MKGUsnTao-1&scaling=min-zoom&starting-point-node-id=217%3A107&show-proto-sidebar=1
* You can click on the PDF and DMP ID links and that they will open in a new tab.
* That you can see the tooltip window saying "Opens in a new window" when you hover over both the PDF icons and the DMP ID links.