### PR TITLE
Br fixes

### DIFF
--- a/app/controllers/api/v3/typeaheads_controller.rb
+++ b/app/controllers/api/v3/typeaheads_controller.rb
@@ -117,7 +117,7 @@ module Api
         out = paginate_response(results: results)
 
         # Add the search term if it was not included in the results already
-        term_matched = out.select do |it|
+        term_matched = results.select do |it|
           it.name&.split(' (')&.first&.downcase&.strip == term.split(' (')&.first&.downcase&.strip
         end
         out.unshift(Org.new(name: term)) unless term_matched.any?

--- a/app/controllers/api/v3/typeaheads_controller.rb
+++ b/app/controllers/api/v3/typeaheads_controller.rb
@@ -29,6 +29,10 @@ module Api
         end
 
         @items = process_results(term: term, matches: matches)
+        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
+
+        # Add the search term if it was not included in the results already
+        @items.unshift(Org.new(name: term)) unless term_matched
         @use_funder_context = true
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
@@ -55,6 +59,11 @@ module Api
 
         # Prepare the results
         @items = process_results(term: term, matches: matches)
+        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
+
+        # Add the search term if it was not included in the results already
+        @items.unshift(Org.new(name: term)) unless term_matched
+
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.orgs #{e.message}"
@@ -73,6 +82,11 @@ module Api
         matches = matches.sort { |a, b| b.research_outputs&.length <=> a.research_outputs&.length }
 
         @items = process_results(term: term, matches: matches)
+        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
+
+        # Add the search term if it was not included in the results already
+        @items.unshift(Org.new(name: term)) unless term_matched
+
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.repositories #{e.message}"
@@ -114,7 +128,6 @@ module Api
       def process_results(term:, matches: [])
         results = deduplicate(term: term, list: matches)
         results.map(&:name).flatten.compact.uniq
-
         paginate_response(results: results)
       end
 

--- a/app/controllers/api/v3/typeaheads_controller.rb
+++ b/app/controllers/api/v3/typeaheads_controller.rb
@@ -29,10 +29,6 @@ module Api
         end
 
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
         @use_funder_context = true
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
@@ -59,11 +55,6 @@ module Api
 
         # Prepare the results
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
-
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.orgs #{e.message}"
@@ -82,11 +73,6 @@ module Api
         matches = matches.sort { |a, b| b.research_outputs&.length <=> a.research_outputs&.length }
 
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
-
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.repositories #{e.message}"
@@ -128,7 +114,14 @@ module Api
       def process_results(term:, matches: [])
         results = deduplicate(term: term, list: matches)
         results.map(&:name).flatten.compact.uniq
-        paginate_response(results: results)
+        out = paginate_response(results: results)
+
+        # Add the search term if it was not included in the results already
+        term_matched = out.select do |it|
+          it.name&.split(' (')&.first&.downcase&.strip == term.split(' (')&.first&.downcase&.strip
+        end
+        out.unshift(Org.new(name: term)) unless term_matched.any?
+        out
       end
 
       # Weighs the result. The greater the weight the closer the match, preferring Orgs already in use

--- a/app/controllers/api/v3/typeaheads_controller.rb
+++ b/app/controllers/api/v3/typeaheads_controller.rb
@@ -29,10 +29,6 @@ module Api
         end
 
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
         @use_funder_context = true
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
@@ -59,11 +55,6 @@ module Api
 
         # Prepare the results
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
-
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.orgs #{e.message}"
@@ -82,11 +73,6 @@ module Api
         matches = matches.sort { |a, b| b.research_outputs&.length <=> a.research_outputs&.length }
 
         @items = process_results(term: term, matches: matches)
-        term_matched = @items.select { |it| it.name&.split(' (')&.first&.downcase&.strip == term.downcase.strip }.any?
-
-        # Add the search term if it was not included in the results already
-        @items.unshift(Org.new(name: term)) unless term_matched
-
         render json: render_to_string(template: '/api/v3/typeaheads/index'), status: :ok
       rescue StandardError => e
         Rails.logger.error "Failure in Api::V3::TypeaheadsController.repositories #{e.message}"
@@ -128,7 +114,6 @@ module Api
       def process_results(term:, matches: [])
         results = deduplicate(term: term, list: matches)
         results.map(&:name).flatten.compact.uniq
-<<<<<<< HEAD
         out = paginate_response(results: results)
 
         # Add the search term if it was not included in the results already
@@ -137,9 +122,6 @@ module Api
         end
         out.unshift(Org.new(name: term)) unless term_matched.any?
         out
-=======
-        paginate_response(results: results)
->>>>>>> 88f107ca4861d3665dd50b50f4d636dc9b503fd7
       end
 
       # Weighs the result. The greater the weight the closer the match, preferring Orgs already in use


### PR DESCRIPTION
Consolidates some redundant code in the typeahead controller.

@jupiter007 I noticed one remaining (and hopefully easy to fix) issue when testing all of the changes again: 
- open a plan on the DMP uploads dashboard and go to the contributors page
- Edit the contributor that is marked as the primary contact
- Uncheck the primary contact box and save
- Then click 'Save and Continue'

It properly shows the error message now, but the contributor disappears from the list. If I refresh the page, the contributor is still there, so it's just a visual issue. This might cause the user to think that the contributor was deleted though and they may try to re-add them.