### PR TITLE
Fixed the issue with Contributors table disappearing when page is re-rendering

### DIFF
--- a/react-client/src/App.js
+++ b/react-client/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react";
 
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
@@ -71,6 +71,11 @@ const router = createBrowserRouter([
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 function App() {
+  
+    useEffect(() => {
+      window.scrollTo(0,0)
+    }, [])
+  
   // If it is Safari, warn the user away
   if (isSafari) {
     return (

--- a/react-client/src/pages/plan/contributors/contributors.js
+++ b/react-client/src/pages/plan/contributors/contributors.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, Fragment } from "react";
+import { useEffect, useState, Fragment, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import {
@@ -27,7 +27,16 @@ function Contributors() {
   const [editIndex, setEditIndex] = useState(null);
   const [contributor, setContributor] = useState(new Contributor({}));
   const [working, setWorking] = useState(false);
+  //This is to handle Contributors errors to display at top of page
+  const [errors, setErrors] = useState([]);
+  const scrollToErrorRef = useRef(null);
 
+  // Want to scroll users to top of page when the arrive
+  // TODO: Add a wrapper to pages to make sure we scroll to top of page when page is loaded
+    useEffect(() => {
+      window.scrollTo(0,0)
+    }, [])
+  
   useEffect(() => {
     getDmp(dmpId).then((initial) => {
       // Force the validation to run silently, so that we can detect contribuor
@@ -147,6 +156,17 @@ function Contributors() {
     }
   }
 
+  /**
+   * Takes dmp.errors map and returns the "contributors" error
+   * @param {*} map 
+   * @returns {string}
+   */
+  const findContributorsError = (map) => {
+    const entriesArray = Array.from(map.entries());
+    const entry = entriesArray.find(([key, value]) => key === "contributors");
+    return entry ? entry[1] : '';
+  }
+
   function handleSave(ev) {
     ev.preventDefault();
     setWorking(true);
@@ -155,9 +175,16 @@ function Contributors() {
     // errors
     if (!dmp.isValid()) {
       if (dmp.errors.has("contributors")) {
-      setDmp(prevState => {
-        return { ...prevState, ...dmp }
-      });
+        // We set a separate Errors state that will trigger a re-render of the body
+        // when there are errors, without triggring an update to the dmp state. Otherwise, the
+        // list of Contributors is empty when there are errors.
+        const contributorsErrors = findContributorsError(dmp.errors);
+        if (contributorsErrors.length > 0) {
+          setErrors(prevErrors => [...prevErrors, contributorsErrors]);
+          setWorking(false);
+          if (scrollToErrorRef.current.scrollIntoView({ behavior: 'smooth' }));
+          return;
+        }
         setWorking(false);
         return
       }
@@ -177,14 +204,14 @@ function Contributors() {
       {!dmp ? (
         <Spinner isActive={true} message="Fetching contributors…" className="page-loader" />
       ) : (
-        <div id="Contributors">
+        <div id="Contributors" ref={scrollToErrorRef}>
           <div className="dmpui-heading">
             <h1>Contributors</h1>
-              {dmp.errors.get("contributors") && (
-                <div className="dmpui-field-error">
-                  {dmp.errors.get("contributors")}
-                </div>
-              )}
+              {errors && errors.map(err => {
+                return (
+                  <div key={err} className="dmpui-field-error">{err}</div>
+                )
+              })}
           </div>
           <p>
             Tell us about the project contributors for your project and, designate

--- a/react-client/src/pages/plan/overview/overview.js
+++ b/react-client/src/pages/plan/overview/overview.js
@@ -23,6 +23,9 @@ function PlanOverview() {
 
   const [serverErrorMessage, setServerErrorMessage] = useState();
 
+    useEffect(() => {
+     window.scrollTo(0,0)
+    },[])
 
   useEffect(() => {
     getDmp(dmpId).then((initial) => {


### PR DESCRIPTION
Changes proposed in this PR:

- Fixed the issue with Contributors table disappearing when page is re-rendered due to errors on the Contributors page. Did this by creating a separate '**errors**' state to display errors. Also, made sure to scroll up to the error message when one is displayed. 
- Updated `App.js` and `overview.js` to include a scroll to the top of the page when the page loads. Eventually, we will want to create a wrapper around all the page components to to this, and to add an appropriate title to each page in the browser


