### PR TITLE
Remove output types

### DIFF
--- a/app/controllers/api/v3/options_controller.rb
+++ b/app/controllers/api/v3/options_controller.rb
@@ -25,7 +25,7 @@ module Api
 
       # GET /api/v3/output_types
       def output_types
-        matches = ResearchOutput.output_types
+        matches = ResearchOutput.output_types.reject { |k, v| %w[event service text workflow].include?(k.downcase) }
         matches = matches.map do |key, val|
           {
             label: key.capitalize.gsub('_', ' '),

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -145,6 +145,12 @@ class Draft < ApplicationRecord
 
       distros = dataset['distribution'].is_a?(Hash) ? dataset['distribution'].values : dataset['distribution']
       dataset['distribution'] = distros
+      dataset['distribution'].each do |distro|
+        next if distro['host'].nil? || !distro['host']['title'].nil?
+
+        repo = Repository.find_by(uri: distro['host']['url'])
+        distro['host']['title'] = repo.name
+      end
       dataset
     end
 

--- a/react-client/src/index.scss
+++ b/react-client/src/index.scss
@@ -494,3 +494,9 @@ dialog {
     text-decoration-thickness: 2px;
     text-decoration-skip-ink: auto;
   }
+
+  #App p.dmpui-field-help {
+    font-size: 0.9rem;
+    color: #555;
+    margin-top: -10px;
+  }

--- a/react-client/src/pages/plan/research-outputs/researchoutputs.js
+++ b/react-client/src/pages/plan/research-outputs/researchoutputs.js
@@ -218,7 +218,7 @@ function ResearchOutputs() {
 
           <div className="dmpdui-list dmpdui-list-research ">
             <div className="data-heading" data-colname="title">
-              Title
+              Proposed Output
             </div>
             <div className="data-heading" data-colname="personal">
               Personal information?
@@ -282,7 +282,7 @@ function ResearchOutputs() {
                 <div className="dmpui-form-cols">
                   <div className="dmpui-form-col">
                     <TextInput
-                      label="Title"
+                      label="Proposed Output"
                       type="text"
                       required="required"
                       name="title"
@@ -312,7 +312,7 @@ function ResearchOutputs() {
                 <div className="dmpui-form-cols">
                   <div className="dmpui-form-col">
                     <SizeInput
-                      label="Repository Size"
+                      label="Estimated size of data"
                       name="size"
                       id="id_size"
                       unitOptions={sizeUnits}
@@ -338,7 +338,7 @@ function ResearchOutputs() {
                     />
 
                     <TextArea
-                      label="Description"
+                      label="Repository description"
                       type="text"
                       inputValue={dataObj.repository.description}
                       onChange={handleChange}
@@ -349,7 +349,7 @@ function ResearchOutputs() {
                     />
 
                     <TextInput
-                      label="URL"
+                      label="Repository URL"
                       type="text"
                       required="required"
                       name="repository_url"
@@ -360,6 +360,7 @@ function ResearchOutputs() {
                       disabled={dataObj.repository.isLocked}
                       hidden={dataObj.repository.isLocked}
                     />
+                    <p class="dmpui-field-help">(e.g., "https://dataverse.org/")</p>
                   </div>
                 </div>
 


### PR DESCRIPTION
Fixes #566 #565.

Changes proposed in this PR:
- Removed a few output types from the research output form's select box
- Updated labels on research output form
- Fix for missing repository names
- Added styling for the example repository URL
- 
