### PR TITLE
Updated DMP Regex logic to account for different environments

### DIFF
--- a/react-client/src/pages/dashboard/dashboard.js
+++ b/react-client/src/pages/dashboard/dashboard.js
@@ -12,7 +12,7 @@ import "./dashboard.scss";
 
 let DMP_ID_REGEX = /\/dmps\/([^/]+\/[^/]+)/; //For local development and stage
 
-if (window.location.hostname === 'dmptool.org' || (process.env.NODE_ENV && process.env.NODE_ENV !== 'development')) {
+if (window.location.hostname === 'dmptool.org' || (process.env.NODE_ENV && process.env.NODE_ENV === 'production')) {
   DMP_ID_REGEX = /[^/]+\/([^/]+\/[^/]+)/
 }
 

--- a/react-client/src/pages/dashboard/dashboard.js
+++ b/react-client/src/pages/dashboard/dashboard.js
@@ -10,7 +10,12 @@ import LookupField from "../../components/lookup-field.js";
 import Spinner from "../../components/spinner";
 import "./dashboard.scss";
 
-const DMP_ID_REGEX = /\/dmps\/([^/]+\/[^/]+)/
+let DMP_ID_REGEX = /\/dmps\/([^/]+\/[^/]+)/; //For local development and stage
+
+if (window.location.hostname === 'dmptool.org' || (process.env.NODE_ENV && process.env.NODE_ENV !== 'development')) {
+  DMP_ID_REGEX = /[^/]+\/([^/]+\/[^/]+)/
+}
+
 function Dashboard() {
   const [projects, setProjects] = useState([]);
   const [previewDmp, setPreviewDmp] = useState({});


### PR DESCRIPTION
Fixes #566

Changes proposed in this PR:
We currently extract the "DMP ID" from the `dmp.landingPageUrl` property, and we use a RegEx to do it. However, the RegEx we were using didn't work for users on Production because there is no "/dmps/" in the path.

So I made a small change to check for the hostname and the NODE environment, and set a different RegEx for production.
