### PR TITLE
Fix issue with typeahead results duplicating the ROR URL

### DIFF
--- a/app/views/branded/api/v3/orgs/_show.json.jbuilder
+++ b/app/views/branded/api/v3/orgs/_show.json.jbuilder
@@ -29,7 +29,7 @@ if org.is_a?(RegistryOrg)
   else
     json.affiliation_id do
       json.type 'ror'
-      json.identifier "https://ror.org/#{org.ror_id}"
+      json.identifier org.ror_id.include?('ror.org') ? org.ror_id : "https://ror.org/#{org.ror_id}"
     end
   end
 

--- a/app/views/branded/api/v3/orgs/_show.json.jbuilder
+++ b/app/views/branded/api/v3/orgs/_show.json.jbuilder
@@ -29,7 +29,9 @@ if org.is_a?(RegistryOrg)
   else
     json.affiliation_id do
       json.type 'ror'
-      json.identifier org.ror_id.include?('ror.org') ? org.ror_id : "https://ror.org/#{org.ror_id}"
+      ror_id = org.ror_id.gsub(%r{https?://}, '').gsub('ror.org', '')
+      ror_id = ror_id.start_with?('/') ? ror_id : "/#{ror_id}"
+      json.identifier "https://ror.org#{ror_id}"
     end
   end
 


### PR DESCRIPTION
Fixes half of #569 by ensuring that we do not return duplicate ROR URLs in the affiliation typeahead results (e.g. `https://ror.org/https://ror.org/1234567`)
