### PR TITLE
Updated the typeahead controller to remove the user-entered value fro…

### DIFF
--- a/app/controllers/api/v3/typeaheads_controller.rb
+++ b/app/controllers/api/v3/typeaheads_controller.rb
@@ -121,13 +121,6 @@ module Api
         results = deduplicate(term: term, list: matches)
         results.map(&:name).flatten.compact.uniq
         out = paginate_response(results: results)
-
-        # Add the search term if it was not included in the results already
-        term_matched = results.select do |it|
-          it.name&.split(' (')&.first&.downcase&.strip == term.split(' (')&.first&.downcase&.strip
-        end
-        out.unshift(Org.new(name: term)) unless term_matched.any?
-        out
       end
 
       # Weighs the result. The greater the weight the closer the match, preferring Orgs already in use

--- a/react-client/src/pages/plan/research-outputs/researchoutputs.js
+++ b/react-client/src/pages/plan/research-outputs/researchoutputs.js
@@ -360,7 +360,7 @@ function ResearchOutputs() {
                       disabled={dataObj.repository.isLocked}
                       hidden={dataObj.repository.isLocked}
                     />
-                    <p class="dmpui-field-help">(e.g., "https://dataverse.org/")</p>
+                    <p class="dmpui-field-help" hidden={dataObj.repository.isLocked}>(e.g., "https://dataverse.org/")</p>
                   </div>
                 </div>
 


### PR DESCRIPTION
#585 

The typeahead controller was updated to remove the user-entered value from the dropdown. Additionally, I fixed the bug where the Repository URL helper text/microtext was still displaying, even when that field was hidden.