### PR TITLE
removed deprecated version line from docker-compose

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -847,6 +847,7 @@ ActiveRecord::Schema.define(version: 2023_12_19_175429) do
     t.index ["user_id"], name: "index_users_perms_on_user_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "answers", "plans"
   add_foreign_key "answers", "questions"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 # NOTE::
 #
 # The services, settings and environment setup in this compose file is

--- a/react-client/src/models.js
+++ b/react-client/src/models.js
@@ -324,7 +324,7 @@ export class DataRepository extends Model {
   set title(val) { this.setData("host.title", val); }
 
   get url() { return this.getData("host.url", ""); }
-  set url(val) { this.setData("host.url", val); }
+  set url(val) { this.setData("host.url", val?.trim()); }
 
   get description() { return this.getData("host.description", ""); }
   set description(val) { this.setData("host.description", val); }

--- a/react-client/src/models.js
+++ b/react-client/src/models.js
@@ -324,7 +324,7 @@ export class DataRepository extends Model {
   set title(val) { this.setData("host.title", val); }
 
   get url() { return this.getData("host.url", ""); }
-  set url(val) { this.setData("host.url", val?.trim()); }
+  set url(val) { this.setData("host.url", val.trim()); }
 
   get description() { return this.getData("host.description", ""); }
   set description(val) { this.setData("host.description", val); }


### PR DESCRIPTION
Fixes #584.

Changes proposed in this PR:
- minor update to the React page to trim leading and trailing whitespace from the URL
- removed a deprecated `version` statement from the docker-compose file
- Rails added a foreign key constraint was added to the schema.rb. I am surprised this was not already in place.
