### PR TITLE
Add plans from DMP Upload pages to API v2

### DIFF
--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -48,6 +48,9 @@ module Api
         @plan = Api::V2::PlansPolicy::Scope.new(@client, @resource_owner, 'both').resolve
                                            .find { |plan| plan.id.to_s == params[:id] }
 
+        # See if it's a Draft if the Plan was not found
+        @plan = Draft.find_by(id: params[:id].gsub('d_', '')) if @plan.nil? &&
+                                                                 @client&.user&.org&.v5_pilot?
         if @plan.present?
           respond_to do |format|
             format.pdf do

--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -23,8 +23,11 @@ module Api
         @scope = 'mine'
         @scope = params[:scope].to_s.downcase if %w[mine public both].include?(params[:scope].to_s.downcase)
 
+        # If the User is part of the pilot project then include their DMP Upload Drafts
+        plans = @client&.user&.org&.v5_pilot? ? Draft.by_org(org_id: @client&.user&.org_id) : []
+
         # See the Policy for details on what Plans are returned to the Caller based on the AccessToken
-        plans = Api::V2::PlansPolicy::Scope.new(@client, @resource_owner, @scope).resolve
+        plans += Api::V2::PlansPolicy::Scope.new(@client, @resource_owner, @scope).resolve
 
         if plans.present? && plans.any?
           plans = plans.sort { |a, b| b.updated_at <=> a.updated_at }

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -51,6 +51,12 @@ class Draft < ApplicationRecord
   validates :narrative, size: { less_than: 250.kilobytes , message: 'PDF too large, must be less than 350KB' },
                         content_type: { in: ['application/pdf'], message: 'must be a PDF document' }
 
+  def self.by_org(org_id:)
+    return [] if org_id.nil?
+
+    includes(:user).joins(:user).where(user: { org_id: org_id })
+  end
+
   # Support for filtering and search
   def self.search(user:, params: {})
     return [] unless user.is_a?(User) && !user.org_id.nil?

--- a/app/views/branded/api/v2/plans/index.json.jbuilder
+++ b/app/views/branded/api/v2/plans/index.json.jbuilder
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+json.partial! 'api/v2/standard_response', total_items: @total_items
+
+json.items @items do |item|
+  if item.is_a?(Plan)
+    json.dmp do
+      json.partial! 'api/v2/plans/show', plan: item
+    end
+  elsif item.is_a?(Draft)
+    json.dmp item.metadata['dmp']
+  end
+end

--- a/app/views/branded/api/v2/plans/index.json.jbuilder
+++ b/app/views/branded/api/v2/plans/index.json.jbuilder
@@ -8,6 +8,22 @@ json.items @items do |item|
       json.partial! 'api/v2/plans/show', plan: item
     end
   elsif item.is_a?(Draft)
+    draft = item.dmp_id.nil? ? item.metadata : DmpIdService.fetch_dmp_id(dmp_id: item.dmp_id)
+    dmp = draft.is_a?(Hash) ? draft['dmp'] : {}
+
+    url = api_v3_draft_url(item.id).gsub('/v3/drafts/', '/v2/plans/')
+                                     .gsub(item.id.to_s, "d_#{item.id}")
+
+    if dmp['dmp_id'].nil?
+      dmp['dmp_id'] = JSON.parse({ type: 'url', identifier: url }.to_json)
+    end
+
+    dmp.delete('draft_data')
+
+    links = { get: url }
+    links[:download] = item.send(:safe_narrative_url) if item.narrative.attached?
+    dmp['dmproadmap_links'] = JSON.parse(links.to_json)
+
     json.dmp item.metadata['dmp']
   end
 end


### PR DESCRIPTION
Fixes #582.

Changes proposed in this PR:
- Adds the plans created via the pilot project DMP Upload pages to the API v2 `GET api/v2/plans` and `GET api/v2/plans/[:id]` endpoints.

We can create an additional ticket for updating/creating/deleting these plans if any of the partners have a need to perform those actions as part of their projects. The ability to do those actions will be more involved.
