### PR TITLE
Increase Upload PDF size to 2MB from 250KB

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -48,7 +48,7 @@ class Draft < ApplicationRecord
   validates_uniqueness_of :dmp_id, allow_blank: true
 
   # Validate that the attachment is a PDF and that it is less than 250KB
-  validates :narrative, size: { less_than: 2.megabytes , message: 'PDF too large, must be less than 350KB' },
+  validates :narrative, size: { less_than: 2.megabytes , message: 'PDF too large, must be less than 2MB' },
                         content_type: { in: ['application/pdf'], message: 'must be a PDF document' }
 
   def self.by_org(org_id:)

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -48,7 +48,7 @@ class Draft < ApplicationRecord
   validates_uniqueness_of :dmp_id, allow_blank: true
 
   # Validate that the attachment is a PDF and that it is less than 250KB
-  validates :narrative, size: { less_than: 250.kilobytes , message: 'PDF too large, must be less than 350KB' },
+  validates :narrative, size: { less_than: 2.megabytes , message: 'PDF too large, must be less than 350KB' },
                         content_type: { in: ['application/pdf'], message: 'must be a PDF document' }
 
   def self.by_org(org_id:)

--- a/react-client/src/pages/plan/setup/setup.js
+++ b/react-client/src/pages/plan/setup/setup.js
@@ -14,7 +14,7 @@ import "./setup.scss";
 function DmpSetup() {
   let navigate = useNavigate();
 
-  const {dmpId} = useParams();
+  const { dmpId } = useParams();
   const [dmp, setDmp] = useState(new DmpModel({}));
   const [errors, setErrors] = useState(new Map());
   const [working, setWorking] = useState(false);
@@ -31,9 +31,9 @@ function DmpSetup() {
   function isValid(fdata) {
     let err = new Map();
 
-    const sizeLimit = 1000000;
+    const sizeLimit = 2000000;
     if (fdata.get("narrative").size > sizeLimit) {
-      err.set("narrative", "File size cannot exceed 1 Mb");
+      err.set("narrative", "File size cannot exceed 2 Mb");
     }
 
     if (!fdata.get("title")) {
@@ -141,10 +141,10 @@ function DmpSetup() {
           <div className="dmpui-form-cols">
             <div className="dmpui-form-col">
               <div className={"dmpui-field-group"}>
-                <label className="dmpui-field-label" for="dmpNarrative">Upload DMP</label>
+                <label className="dmpui-field-label" htmlFor="dmpNarrative">Upload DMP</label>
                 <p className="dmpui-field-help">
                   Only PDFs may be uploaded, and files should be no more than
-                  1MB.
+                  2MB.
                 </p>
                 {errors.get("narrative") && (
                   <p className="dmpui-field-error"> {errors.get("narrative")} </p>


### PR DESCRIPTION
Fixes https://github.com/CDLUC3/dmptool/issues/611 .

Changes proposed in this PR:

Increased file size limit to 2MB in drafts.rb
Increase the file size in setup.js to 2MB and updated the instructional text and error text to match
Fixed a React bug where we needed to use the React syntax of "htmlFor"
Increased the Upload PDF file size from 250KB to 2MB.

Initially we were going to update to 1MB size limit, since the Upload instructions mentioned the size limit was 1MB, but we had a size limit of 250KB in draft.rb.

However, considering the new HTML->PDF generator tends to create larger file sizes, Becky set the new size limit to 2MB.