### PR TITLE
Bug/narrative pdf is not removed from upload plan

### DIFF
--- a/app/controllers/api/v3/drafts_controller.rb
+++ b/app/controllers/api/v3/drafts_controller.rb
@@ -121,12 +121,12 @@ module Api
         dmp.narrative.purge if (create_params[:narrative].present? || create_params[:remove_narrative].present?) &&
                                dmp.narrative.attached?
 
+        # Remove the narrative from the metadata if it was purged
+        dmp.metadata.fetch('dmp', {})['draft_data']['narrative'] = {} if (create_params[:remove_narrative].present?) 
+
         # Attach the narrative PDF if applicable
         dmp.metadata.fetch('dmp', {})['title'] = create_params[:title] if create_params[:title].present?
         dmp.narrative.attach(create_params[:narrative]) if create_params[:narrative].present?
-
-        # Remove the narrative from the metadata if it was purged
-        dmp.metadata.fetch('dmp', {})['draft_data']['narrative'] = {} if (create_params[:remove_narrative].present?)
 
         if dmp.save
           @drafts = [dmp]

--- a/app/controllers/api/v3/drafts_controller.rb
+++ b/app/controllers/api/v3/drafts_controller.rb
@@ -122,7 +122,7 @@ module Api
                                dmp.narrative.attached?
 
         # Remove the narrative from the metadata if it was purged
-        dmp.metadata.fetch('dmp', {})['draft_data']['narrative'] = {} if (create_params[:remove_narrative].present?) 
+        dmp.metadata.fetch('dmp', {})['draft_data']['narrative'] = {} if dmp.metadata.fetch('dmp', {})['draft_data'].present? && create_params[:remove_narrative].present?
 
         # Attach the narrative PDF if applicable
         dmp.metadata.fetch('dmp', {})['title'] = create_params[:title] if create_params[:title].present?

--- a/app/controllers/api/v3/drafts_controller.rb
+++ b/app/controllers/api/v3/drafts_controller.rb
@@ -124,6 +124,10 @@ module Api
         # Attach the narrative PDF if applicable
         dmp.metadata.fetch('dmp', {})['title'] = create_params[:title] if create_params[:title].present?
         dmp.narrative.attach(create_params[:narrative]) if create_params[:narrative].present?
+
+        # Remove the narrative from the metadata if it was purged
+        dmp.metadata.fetch('dmp', {})['draft_data']['narrative'] = {} if (create_params[:remove_narrative].present?)
+
         if dmp.save
           @drafts = [dmp]
           render json: render_to_string(template: '/api/v3/drafts/index'), status: :ok

--- a/react-client/src/pages/plan/setup/setup.js
+++ b/react-client/src/pages/plan/setup/setup.js
@@ -154,7 +154,7 @@ function DmpSetup() {
 
                   <div className="dmpui-field-fileinput-group">
                     <div>
-                      {dmp.narrative && (
+                      {dmp.narrative?.url && (
                         <>
                           <p>
                             <a href={dmp.narrative?.url} target="_blank">{dmp.narrative?.file_name}</a>


### PR DESCRIPTION
Fixes #  [#563](https://github.com/CDLUC3/dmptool/issues/563)

Changes proposed in this PR:
- Added a small change to `draft_controller.rb` to remove the `narrative` from the `metadata` if `remove_narrative` param was present.
- Updated the condition in which the "**Remove PDF**" checkbox is displayed to check for the existence of the `dmp.narrative.url `instead since just checking for "`dmp.narrative`" was not working when **null**.


Test Steps that I completed
1. Click on "Upload Plan" and then the "Add Plan" button
2. Enter Project Name and Upload a PDF
3. Click "Save & Continue"
4. Clicked "Yes, I have a funder" radio button and entered "NSF" as the Funder Name
5. Clicked "Save & Continue"
6. Entered "praetzellis" as Principal Investigator, and selected "EAGER: SMART-DMSP" and clicked "Save & Continue" and then "Save & Continue" again
7. Clicked on "Project name & PDF upload"
8. Checked the "Remove PDF" checkbox  and clicked "Save & Continue"
9. Went back into "Project name & Pdf upload", and noticed that the PDF no longer displayed
10. I checked the database table, and noted that the narrative was removed from the metadata and that the PDF was no longer in the "active storage" tables.
11. I uploaded a new PDF and clicked "Save & Continue"
12. I then returned to "Project name & PDF upload" and saw that the new PDF was there.
