### PR TITLE
Added new 'domain' to allowed params for api/v3/dmps_controller

### DIFF
--- a/app/controllers/api/v3/base_api_controller.rb
+++ b/app/controllers/api/v3/base_api_controller.rb
@@ -207,7 +207,7 @@ module Api
       def modifications_params
         %i[id augmenter_run_id provenance timestamp] + [
           dmproadmap_related_identifiers: %i[descriptor work_type type identifier citation
-                                             confidence score status] + [notes: []],
+                                             domain confidence score status] + [notes: []],
           funding: %i[name acronym funding_status dmproadmap_opportunity_number dmproadmap_project_number
                       confidence score status] +
                       [notes: [], funder_id: identifier_permitted_params, grant_id: identifier_permitted_params]


### PR DESCRIPTION
Fixes #626

- Added `domain` as an acceptable controller param for `dmphub_modifications`