### PR TITLE
updated 2 partials to use the newer dmp_id_for_display helper function.

### DIFF
--- a/app/views/paginable/plans/_index.html.erb
+++ b/app/views/paginable/plans/_index.html.erb
@@ -36,9 +36,7 @@
           <% if has_dmp_id %>
             <td>
               <% if plan.dmp_id.present? %>
-                <a href="<%= plan.dmp_id.value %>" target="_blank" class="has-new-window-popup-info">
-                  <%= id_for_display(id: plan.dmp_id, with_scheme_name: false).html_safe %>
-                </a>
+                <%= dmp_id_for_display(dmp_id: plan.dmp_id, without_prefix: true).html_safe %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -50,9 +50,7 @@
           <% if has_dmp_id %>
             <td>
               <% if plan.dmp_id.present? %>
-                <a href="<%= plan.dmp_id.value %>" target="_blank" class="has-new-window-popup-info">
-                  <%= id_for_display(id: plan.dmp_id, with_scheme_name: false).html_safe %>
-                </a>
+                <%= dmp_id_for_display(dmp_id: plan.dmp_id, without_prefix: false).html_safe %>
               <% end %>
             </td>
           <% end %>


### PR DESCRIPTION
Fixes #576.

Changes proposed in this PR:
- We missed 2 partials when updating where/how the DMP ID gets stored for the pilot project. Updated the partials to use the new `dmp_id_for_display` function
