### PR TITLE
Patch bug causing an issue when users add collaborators to their plan

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -69,7 +69,7 @@ class RolesController < ApplicationController
           if @role.save
             if registered
               deliver_if(recipients: user, key: 'users.added_as_coowner') do |r|
-                UserMailer.sharing_notification(@role, r, inviter: current_user)
+                UserMailer.sharing_notification(@role, r, current_user)
                           .deliver_now
               end
             end


### PR DESCRIPTION
Fixes #650

- Code was using a mix of named and unnamed parameters. 
