### PR TITLE
Fixed a bug that was causing content to be excluded from .docx export…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v4.1.6
+- Fixed a bug that was causing content to be excluded from .docx exports. Updated clean_html_for_docx_creation function [#647]
+
 ### v4.1.5
 
 - Added the ability for users to change the font size, font color, text alignment in the TinyMCE editors. See app/javascript/utils/tinymce.js.

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -201,6 +201,9 @@ class PlanExportsController < ApplicationController
   # in html that break docx creation by htmltoword gem.
   def clean_html_for_docx_creation(html)
     # Replaces single backslash \ with \\ with gsub.
-    html.gsub('\\', '\&\&')
+    # Then replaces a specific pattern of tags that causes content to not be included in exported docx.
+      # \1 refers to the first captured group in parenthesis. <br> tag is replaced with </p></p>. \3 refers to all remaining content 
+      # up to and including the closing </p> tag.
+    html.gsub('\\', '\&\&').gsub(/(<p>.*?<strong>.*?<\/strong>[^<]+)(<br>)(.*?<\/p>)/, '\1</p><p>\3')
   end
 end

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -202,7 +202,7 @@ class PlanExportsController < ApplicationController
   def clean_html_for_docx_creation(html)
     # Replaces single backslash \ with \\ with gsub.
     # Then replaces a specific pattern of tags that causes content to not be included in exported docx.
-      # \1 refers to the first captured group in parenthesis. <br> tag is replaced with </p></p>. \3 refers to all remaining content 
+      # \1 refers to the first captured group in parenthesis. <br> tag is replaced with </p><p>. \3 refers to all remaining content 
       # up to and including the closing </p> tag.
     html.gsub('\\', '\&\&').gsub(/(<p>.*?<strong>.*?<\/strong>[^<]+)(<br>)(.*?<\/p>)/, '\1</p><p>\3')
   end


### PR DESCRIPTION
We recently discovered that text in exported .docx plans was sometimes missing.

I did some research into it and it appears that docx is not happy when there is a <strong></strong> tag, then some text or characters, then a <br> tag all within a <p></p> tag. All content after the <br> tag, within that <p></p> tag is somehow not included in the exported plan.

Fixes #647 

Changes proposed in this PR:
- I added another `.gsub()` replacement regex to the `clean_html_for_docx_creation(html)` function in `plan_exports_controller.rb`. This should find those cases described above, and replace the `<br> `tag with a closing `</p>` and an opening `<p>` tag.

Testing:

1. I copied over the problematic content referenced in the ticket, into my plan. 
"Biochemical Assay Data: Results from various biochemical assays assessing the binding and cleaving activities of NLRP3 and other pyrin-domain proteins on oxidized DNA.
Cell Signaling Data: Measurements from cell-based assays evaluating the activation of NLRP3 inflammasome and downstream signaling pathways under different stress conditions."

"Public Repositories: Published data will be deposited in publicly accessible repositories such as the Electron Microscopy Data Bank (EMDB) and the Protein Data Bank (PDB) for long-term access and preservation.
Constructs and Reagents:"

"Direct Requests: Researchers can email redacted name for privacy to request reagents and materials needed to duplicate the data, facilitating reproducibility and collaboration."

2. I then downloaded a `.docx` file WITHOUT my regex fix. You can see where the missing content should be in the outlined red boxes:
<img width="571" alt="image" src="https://github.com/user-attachments/assets/c84685ca-87a6-48d5-8e63-46beb9f3c515">


3. Then I added my regex fix, and downloaded the `.docx` file again. You can see the missing content is now present, and the formatting looks the same as in the originally entered text in the plan:

<img width="597" alt="image" src="https://github.com/user-attachments/assets/108863d3-4950-491b-af47-1b7fc536f77d">




