### PR TITLE
Fix application name that appears in emails

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -5,7 +5,7 @@ module MailerHelper
   include PermsHelper
 
   def tool_name
-    @tool_name ||= ApplicationService.application_name
+    @tool_name ||= Rails.configuration.x.dmproadmap.application_name
   end
 
   def helpdesk_email(org: nil)

--- a/config/dmproadmap.yml
+++ b/config/dmproadmap.yml
@@ -287,7 +287,7 @@ default: &default
   # This name is used throughout the system to identify your application. (e.g. in
   # email communications, API calls to external systems, etc.)
   # NOTE - This name must match the Google Analytics Tracker in this file!
-  application_name: "MyApp"
+  application_name: "DMPTool"
   # The :from email address used in emails sent by the application
   application_do_not_reply_email: "do-not-reply-my-app-dev@cdlib.org"
   # The helpdesk email

--- a/config/dmproadmap.yml
+++ b/config/dmproadmap.yml
@@ -287,7 +287,7 @@ default: &default
   # This name is used throughout the system to identify your application. (e.g. in
   # email communications, API calls to external systems, etc.)
   # NOTE - This name must match the Google Analytics Tracker in this file!
-  application_name: "DMPTool"
+  application_name: "DMP Tool"
   # The :from email address used in emails sent by the application
   application_do_not_reply_email: "do-not-reply-my-app-dev@cdlib.org"
   # The helpdesk email


### PR DESCRIPTION
Missed a config value when upgrading to Rails 7.2

Changed 'AppName' to 'DMP Tool'