### PR TITLE
Add logstash and lograge to the Rails app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,6 +273,12 @@ gem 'daemons'
 # See: https://github.com/igorkasyanchuk/active_storage_validations
 gem 'active_storage_validations'
 
+# Lograge is an attempt to bring sanity to Rails' noisy and unusable, unparsable and, in the
+# context of running multiple processes and servers, unreadable default logging output.
+#
+# See: https://github.com/roidrage/lograge
+gem 'lograge'
+
 # ================================= #
 # ENVIRONMENT SPECIFIC DEPENDENCIES #
 # ================================= #

--- a/Gemfile
+++ b/Gemfile
@@ -279,6 +279,13 @@ gem 'active_storage_validations'
 # See: https://github.com/roidrage/lograge
 gem 'lograge'
 
+# Logstash is part of the Elastic Stack along with Beats, Elasticsearch and Kibana. Logstash
+# is a server-side data processing pipeline that ingests data from a multitude of sources
+# simultaneously, transforms it, and then sends it to your favorite "stash."
+#
+# See: https://github.com/elastic/logstash
+gem 'logstash-event'
+
 # ================================= #
 # ENVIRONMENT SPECIFIC DEPENDENCIES #
 # ================================= #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     locale (2.1.4)
     logger (1.6.1)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -563,6 +568,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -767,6 +774,7 @@ DEPENDENCIES
   kaminari
   ledermann-rails-settings
   listen
+  lograge
   mail
   mimemagic
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,6 +386,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -775,6 +776,7 @@ DEPENDENCIES
   ledermann-rails-settings
   listen
   lograge
+  logstash-event
   mail
   mimemagic
   mocha

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :password, :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :password, :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp,
+  :ssn, :current_password, :password_confirmation, :client_secret
 ]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,37 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+
+  # Use the LogStash format
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+
+  # Include controller info in the available log payload
+  config.lograge.custom_payload do |controller|
+    {
+      host: controller.request.host,
+      user_id: controller.current_user.try(:id)
+      params: controller.params
+    }
+  end
+
+  # Include the custom info from the event and payload
+  config.lograge.custom_options = lambda do |event|
+    param_exceptions = %w(controller action format id)
+
+    {
+      # Timestamp
+      time: event.time,
+      # Controller params
+      params: event.payload[:params].except(*param_exceptions),
+      # The current user
+      user: event.payload[:user_id],
+      # Caller
+      host: event.payload[:host]
+    }
+  end
+
+  # Continue creating the basic Rails logs
+  config.lograge.keep_original_rails_log = true
+
+  # Define the location of the Lograge format
+  config.lograge.logger = ActiveSupport::Logger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
+end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   config.lograge.enabled = true
 
-  # Use the LogStash format
+  # Use the LogStash format to get JSON instead of the standard Lograge one-liners
   config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   # Include controller info in the available log payload
@@ -9,23 +9,15 @@ Rails.application.configure do
     {
       host: controller.request.host,
       user_id: controller.current_user.try(:id),
-      params: controller.params
     }
   end
 
   # Include the custom info from the event and payload
   config.lograge.custom_options = lambda do |event|
-    param_exceptions = %w(controller action format id)
+    params_to_skip = %w[_method action authenticity_token commit controller format id]
 
     {
-      # Timestamp
-      time: event.time,
-      # Controller params
-      params: event.payload[:params].except(*param_exceptions),
-      # The current user
-      user: event.payload[:user_id],
-      # Caller
-      host: event.payload[:host]
+      params: event.payload[:params].except(*params_to_skip)
     }
   end
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -7,16 +7,21 @@ Rails.application.configure do
   # Include controller info in the available log payload
   config.lograge.custom_payload do |controller|
     {
-      host: controller.request.host,
+      # host: controller.request.host,
+      ip: controller.request.ip,
       user_id: controller.current_user.try(:id),
     }
   end
+
+  # Skip the Home page because the load balancer pings it every other second and it's noisy
+  config.lograge.ignore_actions = ['HomeController#index']
 
   # Include the custom info from the event and payload
   config.lograge.custom_options = lambda do |event|
     params_to_skip = %w[_method action authenticity_token commit controller format id]
 
     {
+      time: event.time,
       params: event.payload[:params].except(*params_to_skip)
     }
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   config.lograge.custom_payload do |controller|
     {
       host: controller.request.host,
-      user_id: controller.current_user.try(:id)
+      user_id: controller.current_user.try(:id),
       params: controller.params
     }
   end


### PR DESCRIPTION
Fixes #682 

Lograge allow us to log to a file in the logstash format AND retain the existing Rails logs. This will be helpful in the event that we need to do a deep dive into them to investigate an issue.

- Added logstash-event gem
- Added lograge gem
- Added lograge confirguration
- Added some additional password and client_secret fields to the Rails log config so that they get filtered by default

Deployed and running in stage. The new logs can be reviewed in the `/dmp/apps/dmptool/shared/log/lograge_stage.log` file
