### PR TITLE
Bug fix: Org merge

### DIFF
--- a/app/validators/org_links_validator.rb
+++ b/app/validators/org_links_validator.rb
@@ -8,10 +8,10 @@ class OrgLinksValidator < ActiveModel::Validator
     links = record.links
     if links.is_a?(Hash)
       unless links.with_indifferent_access.key?('org')
-        record.errors.add(:links, 'A key "org" is expected for links hash')
+        record.errors.add(:links, _('A key "org" is expected for links hash'))
       end
     else
-      record.errors.add(:links, 'A hash is expected for links')
+      record.errors.add(:links, _('A hash is expected for links'))
     end
   end
 end

--- a/app/validators/org_links_validator.rb
+++ b/app/validators/org_links_validator.rb
@@ -8,10 +8,10 @@ class OrgLinksValidator < ActiveModel::Validator
     links = record.links
     if links.is_a?(Hash)
       unless links.with_indifferent_access.key?('org')
-        record.errors.add(:links, format(_('A key "org" is expected for links hash'), key: k))
+        record.errors.add(:links, 'A key "org" is expected for links hash')
       end
     else
-      record.errors.add(:links, _('A hash is expected for links'))
+      record.errors.add(:links, 'A hash is expected for links')
     end
   end
 end


### PR DESCRIPTION
Fixes #695

Changes proposed in this PR:
- Remove unnecessary `format` command from error because `k` does not appear in text and is not defined
