### PR TITLE
Send emails when monthly tasks fail

### DIFF
--- a/app/mailers/dmptool/mailer.rb
+++ b/app/mailers/dmptool/mailer.rb
@@ -3,6 +3,8 @@
 module Dmptool
   # DMPTool specific mailers
   module Mailer
+    include MailerHelper
+
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
     def invitation(inviter, invitee, plan)
       @invitee = invitee
@@ -90,6 +92,16 @@ module Dmptool
       @sender = sender
       I18n.with_locale I18n.default_locale do
         mail(to: recipient.email, cc: sender.email, subject: subject)
+      end
+    end
+
+    # Sends a Rake failure to the helpdesk email
+    def rake_failure(subj:, err:)
+      @subj = subj || 'Rake task failure'
+      @err = err || StandardError.new('Something went wrong!')
+
+      I18n.with_locale I18n.default_locale do
+        mail(to: helpdesk_email, subject: subj)
       end
     end
   end

--- a/app/views/branded/user_mailer/rake_failure.html.erb
+++ b/app/views/branded/user_mailer/rake_failure.html.erb
@@ -1,0 +1,8 @@
+<h1>Scheduled job failure!</h1>
+<p><%= @subj %></p>
+<br>
+<p><strong>Message:</strong> <%= @err.message %></p>
+<br>
+<p><strong>Backtrace:</strong> <%= @err.backtrace %></p>
+<br>
+<p>Thank you, Please do not reply to this email.</p>


### PR DESCRIPTION
Fixes #716.

Changes proposed in this PR:
- Add a new `rake_failure` mailer
- Update the `housekeeping:monthly_maintenance` job to send emails to the helpdesk on a failure and continue with next job.
