### PR TITLE
Fixed missing background color in klaro button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v5.41
+- Update klaro styles to use `klaro-ui-light` to try and fix missing background button color
+
 ### v5.40
 - Patched bug with adding published DMP-IDs to the owner's ORCID works (missing config attr `orcid_active`)
 - Patched bug with viewing 3rd party connection that has no logo

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -97,7 +97,7 @@ import './src/superAdmin/users/edit';
 
 // Add Klaro consent manager imports
 import 'klaro-ui/dist/js/klaro-config.js';
-import 'klaro-ui/dist/css/klaro-ui.css';
+import 'klaro-ui/dist/css/klaro-ui-light.css';
 
 // ==========================
 // = DMPTool customizations =


### PR DESCRIPTION
Fixes [# 723](https://github.com/CDLUC3/dmptool/issues/723)

Changes proposed in this PR:
- Switched out use of `klaro-ui.css` with `klaro-ui-light.css` to prevent loading of css in different orders, which caused the `klaro` button to have no background color.
