### PR TITLE
Removed the import of the dist/css/klaro-ui.css file, since it is dif…

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -97,7 +97,6 @@ import './src/superAdmin/users/edit';
 
 // Add Klaro consent manager imports
 import 'klaro-ui/dist/js/klaro-config.js';
-import 'klaro-ui/dist/css/klaro-ui.css';
 
 // ==========================
 // = DMPTool customizations =


### PR DESCRIPTION
Removed the import of the dist/css/klaro-ui.css file, since it is different on stage and production from dev for some reason

Fixes # [723](https://github.com/CDLUC3/dmptool/issues/723)

Changes proposed in this PR:
- Removed the import of "dist/css/klaro-ui.css" from the application.js file, since it contains different styles than on our "dev" environment, and we are now using the "app/assets/stylesheets/dmptool/_klaro.scss" styles instead.
I think there's something different in the build process that is not allowing the `dist/css/klaro-ui.css` file to be built in the same way between dev and stage/prod.
