### PR TITLE
Direct logins for mit.edu to shibboleth that works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ storage/
 /config/credentials/stage.yaml.enc
 /config/credentials/production.key
 /config/credentials/production.yaml.enc
+.nvmrc

--- a/app/models/concerns/dmptool/org.rb
+++ b/app/models/concerns/dmptool/org.rb
@@ -67,6 +67,12 @@ module Dmptool
           return nil if matches.empty? || matches.first.org_id.nil?
 
           ::Org.find_by(id: matches.first.org_id)
+
+        when /\A(?:.+\.)?mit\.edu\z/
+          matches = ::RegistryOrg.where("home_page LIKE '%web.mit.edu'")
+          return nil if matches.empty? || matches.first.org_id.nil?
+
+          ::Org.find_by(id: matches.first.org_id)
         else
           nil
         end

--- a/app/models/concerns/dmptool/org.rb
+++ b/app/models/concerns/dmptool/org.rb
@@ -68,7 +68,7 @@ module Dmptool
 
           ::Org.find_by(id: matches.first.org_id)
 
-        when /\A(?:.+\.)?mit\.edu\z/
+        when "mit.edu"
           matches = ::RegistryOrg.where("home_page LIKE '%web.mit.edu'")
           return nil if matches.empty? || matches.first.org_id.nil?
 


### PR DESCRIPTION
Fixes https://github.com/CDLUC3/dmptool/issues/774 .

Changes proposed in this PR:

This makes the `<email>@mit.edu` have shibboleth enabled and direct shibboleth login to the web.mit.edu settings which have a working shibboleth.

Deployed to stage and tested.


<img width="387" height="308" alt="Screenshot 2026-01-12 at 4 10 03 PM" src="https://github.com/user-attachments/assets/6c200d90-05c4-4bb5-b971-239a0ca373f4" />

<img width="393" height="553" alt="Screenshot 2026-01-12 at 4 12 25 PM" src="https://github.com/user-attachments/assets/4e248335-5b9b-4b22-aedb-7590a659fdcd" />

<img width="790" height="474" alt="Screenshot 2026-01-12 at 4 12 49 PM" src="https://github.com/user-attachments/assets/a7c836aa-f0b8-479c-b558-a39615e77aea" />


Other mit subdomains still act as they would normally.  (Like this one has no shibboleth.)

<img width="407" height="301" alt="Screenshot 2026-01-12 at 4 13 07 PM" src="https://github.com/user-attachments/assets/7d3ac544-75b5-4599-b452-57a720ab2c2c" />

<img width="395" height="839" alt="Screenshot 2026-01-12 at 4 13 17 PM" src="https://github.com/user-attachments/assets/10b75c1c-cf6e-4066-ab8c-0ad99973dda0" />

