### PR TITLE
Fix font size in downloaded PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ app/assets/images/homepage
 
 # Ignore all logfiles, tempfiles, public assets,
 /log/*.log
+/log/*.log.*
 /tmp
 
 # Ignore webpack generate images in public folder

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -97,7 +97,7 @@ class PlanExportsController < ApplicationController
   private
 
   def show_html
-    render layout: false
+    render layout: false, locals: { export_format: 'html' }
   end
 
   def show_csv
@@ -131,7 +131,7 @@ class PlanExportsController < ApplicationController
       redirect_to rails_blob_path(@plan.narrative, disposition: "attachment") and return if @plan.narrative.present? &&
                                                                                             @from_public_plans_page
 
-      html = render_to_string(partial: '/shared/export/plan')
+      html = render_to_string(partial: '/shared/export/plan', locals: { export_format: 'pdf' })
 
       grover_options = {
         margin:  {

--- a/app/views/branded/shared/export/_plan.erb
+++ b/app/views/branded/shared/export/_plan.erb
@@ -8,7 +8,8 @@
                locals: {
                  font_face: font_face,
                  font_size: "#{font_size}pt",
-                 margin: "#{margin_top}px #{margin_right}px #{margin_bottom}px #{margin_left}px"
+                 margin: "#{margin_top}px #{margin_right}px #{margin_bottom}px #{margin_left}px",
+                 export_format: local_assigns[:export_format]
                } %>
   </head>
   <body>

--- a/app/views/branded/shared/export/_plan_styling.erb
+++ b/app/views/branded/shared/export/_plan_styling.erb
@@ -26,6 +26,18 @@ def margin_mm_to_px(val)
   return crosswalk[val.to_s.to_sym] || crosswalk[:'25']
 end
 
+def pt_to_px(val)
+  # Strips "pt" suffix if present, converts to px for consistent Chromium print rendering
+  # e.g. "11pt" → "14.67px", "12pt" → "16.0px"
+  if val.to_s =~ /^([\d.]+)pt$/
+    px = ($1.to_f * 96.0 / 72.0).round(2)
+    "#{px}px"
+  else
+    val  # already px, em, or unknown — pass through unchanged
+  end
+end
+
+
 # The Grover PDF top and bottom margins do not match the WkHtmlToPdf margins, so reduce them down a bit
 margin_top = (margin_top.to_s =~ /[\d]+/) == 0 ? (margin_top.to_s.to_i - 4).to_s : '20'
 margin_bottom = (margin_bottom.to_s =~ /[\d]+/) == 0 ? (margin_bottom.to_s.to_i - 4).to_s : '20'
@@ -40,7 +52,7 @@ margin_bottom = (margin_bottom.to_s =~ /[\d]+/) == 0 ? (margin_bottom.to_s.to_i 
   }
   body {
     font-family: <%= font_face %>;
-    font-size: <%= font_size %>;
+    font-size: <%= (export_format == 'pdf' || export_format.nil?) ? pt_to_px(font_size) : font_size %>;  <%# Convert pt to px for PDF, keep as pt for DOCX/HTML %>
     line-height: 120%;
   }
   .break-after {

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -8,7 +8,8 @@
                locals: {
                  font_face: font_face,
                  font_size: "#{font_size}pt",
-                 margin: "#{margin_top}px #{margin_right}px #{margin_bottom}px #{margin_left}px"
+                 margin: "#{margin_top}px #{margin_right}px #{margin_bottom}px #{margin_left}px",
+                 export_format: local_assigns[:export_format]
                } %>
   </head>
   <body>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
-  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -135,7 +135,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["roles"], name: "index_contributors_on_roles"
   end
 
-  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -159,7 +159,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["org_id"], name: "index_departments_on_org_id"
   end
 
-  create_table "drafts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "drafts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "draft_id"
     t.json "metadata", null: false
     t.integer "user_id"
@@ -213,7 +213,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
   end
 
-  create_table "hidden_dmps", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "hidden_dmps", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "dmp_id", null: false
     t.datetime "created_at", null: false
@@ -243,7 +243,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.string "identifiable_type"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.datetime "last_sync_at", precision: nil
     t.index ["identifiable_type", "identifiable_id"], name: "index_identifiers_on_identifiable_type_and_identifiable_id"
     t.index ["identifier_scheme_id", "identifiable_id", "identifiable_type"], name: "index_identifiers_on_scheme_and_type_and_id"
     t.index ["identifier_scheme_id", "value"], name: "index_identifiers_on_identifier_scheme_id_and_value"
@@ -549,7 +548,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.integer "super_region_id"
   end
 
-  create_table "registry_orgs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "registry_orgs", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "org_id"
     t.string "ror_id"
     t.string "fundref_id"
@@ -707,27 +706,27 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
     t.index ["subscriber_id", "subscriber_type", "plan_id"], name: "index_subscribers_on_identifiable_and_plan_id"
   end
 
-  create_table "template_licenses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "template_licenses", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "template_id"
     t.bigint "license_id"
     t.index ["license_id"], name: "index_template_licenses_on_license_id"
     t.index ["template_id"], name: "index_template_licenses_on_template_id"
   end
 
-  create_table "template_metadata_standards", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "template_metadata_standards", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "template_id"
     t.bigint "metadata_standard_id"
     t.index ["metadata_standard_id"], name: "index_template_metadata_standards_on_metadata_standard_id"
     t.index ["template_id"], name: "index_template_metadata_standards_on_template_id"
   end
 
-  create_table "template_output_types", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "template_output_types", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "template_id"
     t.string "research_output_type"
     t.index ["template_id"], name: "index_template_output_types_on_template_id"
   end
 
-  create_table "template_repositories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "template_repositories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "template_id"
     t.bigint "repository_id"
     t.index ["repository_id"], name: "index_template_repositories_on_repository_id"
@@ -850,6 +849,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_21_160500) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "annotations", "orgs"
+  add_foreign_key "annotations", "questions"
   add_foreign_key "answers", "plans"
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"


### PR DESCRIPTION

Fixes # [101](https://github.com/CDLUC3/dmptool-doc/issues/101)

Changes proposed in this PR:
- Added `pt_to_px` function to _plan_styling.erb to convert to px to compensate for Chromium's DPI handling during PDF generation.
- Added `export_format` param to the `render` call so we can distinguish between what type of file is being rendered

A copy of an exported PDF is attached to the ticket: https://github.com/user-attachments/files/25780175/Arctic_Fisheries.4.pdf

I did some research on the docx download issue, and I think it should be handled in a separate ticket, because it's more complicated. I think we need to use something like pandoc to convert HTML to .docx, but we will have to configure the styles in a separate reference file. The htmltoword appeared to be the culprit for the tiny font sizes. htmltoword's XLST transformation incorrectly reads 11pt asn 11px, and then it converts the ``px to Word document units: 11px x 92/96 = ~8.25pt. The htmltoword strips the `pt` suffix, and applies its own conversion.

