### PR TITLE
update to ruby v3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # This Dockerfile is meant for running the application in an AWS ECS container. The required
 # Rails credentials and ENV variables are all defined by the CloudFormation template and passed
 # into the container on startup
-FROM ruby:3.3
+FROM ruby:3.4
 
 RUN echo $(apt-cache search magick)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN echo $(apt-cache search magick)
 # Add NodeJS and Yarn repositories to apt-get
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-# Installing Node 20.x
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+# Installing Node 22.x
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash
 
 # Install packages
 RUN apt-get clean

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim-bookworm
+FROM ruby:3.4-slim-bookworm
 
 RUN groupadd -g 1000 dmpt && useradd -u 1000 -g 1000 dmpt
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,7 @@ RUN set -ex \
     && rm -rf /var/lib/apt/lists/*
 
 # Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get install -y nodejs
 
 # Install yarn

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '>= 3.3'
+ruby '>= 3.4'
 
 # ===========#
 # CORE RAILS #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CDLUC3/uc3-ssm
-  revision: 2adc66b042e26b0ed2530b0e4660bab7e366e33c
+  revision: 550bdb6adbf659ea0faaa4dde909e7b68c227e9b
   specs:
     uc3-ssm (1.0.3)
 
@@ -89,9 +89,9 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.8)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
-    airbrussh (1.6.0)
+    airbrussh (1.6.1)
       sshkit (>= 1.6.1, != 1.7.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
@@ -105,8 +105,8 @@ GEM
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1220.0)
-    aws-sdk-core (3.242.0)
+    aws-partitions (1.1223.0)
+    aws-sdk-core (3.243.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -117,8 +117,8 @@ GEM
     aws-sdk-kms (1.122.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.213.0)
-      aws-sdk-core (~> 3, >= 3.241.4)
+    aws-sdk-s3 (1.215.0)
+      aws-sdk-core (~> 3, >= 3.243.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sdk-ssm (1.211.0)
@@ -146,7 +146,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     bullet (8.1.0)
@@ -252,7 +252,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
-    doorkeeper (5.8.2)
+    doorkeeper (5.9.0)
       railties (>= 5)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
@@ -270,7 +270,7 @@ GEM
     ed25519 (1.4.0)
     erb (6.0.2)
     erubi (1.13.1)
-    excon (1.3.2)
+    excon (1.4.0)
       logger
     execjs (2.10.0)
     factory_bot (6.5.6)
@@ -278,7 +278,7 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faker (3.6.0)
+    faker (3.6.1)
       i18n (>= 1.8.11, < 2)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
@@ -333,7 +333,7 @@ GEM
       rchardet (~> 1.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    grover (1.2.8)
+    grover (1.2.9)
       nokogiri (~> 1)
     guard (2.20.1)
       formatador (>= 0.2.4)
@@ -373,7 +373,10 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.18.1)
+    json (2.19.1)
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -427,11 +430,13 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    mcp (0.8.0)
+      json-schema (>= 4.1)
     method_source (1.1.0)
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0224)
+    mime-types-data (3.2026.0303)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
@@ -546,7 +551,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     puma (7.2.0)
       nio4r (~> 2.0)
     pundit (2.5.2)
@@ -640,7 +645,7 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (8.0.3)
@@ -654,10 +659,11 @@ GEM
     rspec-support (3.13.7)
     rss (0.3.2)
       rexml
-    rubocop (1.84.2)
+    rubocop (1.85.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
+      mcp (~> 0.6)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
@@ -897,7 +903,7 @@ DEPENDENCIES
   zaru
 
 RUBY VERSION
-   ruby 3.3.9p170
+   ruby 3.4.8p72
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
Fixes [#20](https://github.com/CDLUC3/dmptool-doc/issues/20)

- Upgrade Gemfile and Dockerfiles to use Ruby 3.4 (need to coordinate update via puppet)
- Upgrade Dockerfiles to Node v22 (this is done on the EC2 instances via puppet)
