### PR TITLE
Reverted pandoc changes for show_docx function for now

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -116,49 +116,11 @@ class PlanExportsController < ApplicationController
               filename: "#{file_name}.txt"
   end
 
-  # A method to preprocess the HTML content for better compatibility with Pandoc text alignment when converting to DOCX.
-  # Looks for 'text-align' styles in <p> tags and replaced them with custom styles which were created in pandoc_reference.docx.
-  def preprocess_alignment(html)
-  html.gsub(/<p style="text-align:(center|right|justify);">(.*?)<\/p>/im) do
-    align = $1.capitalize
-    content = $2
-    "<div custom-style=\"Align#{align}\"><p>#{content}</p></div>"
-    end
-  end
-
-
   def show_docx
-    begin
-      html = render_to_string(partial: 'shared/export/plan', locals: { export_format: 'docx' })
-      html = preprocess_alignment(html)
-
-      docx_path     = Rails.root.join('tmp', "#{file_name}.docx")
-      html_path     = Rails.root.join('tmp', "#{file_name}.html")
-      reference_doc = Rails.root.join('lib', 'templates', 'pandoc_reference.docx')
-
-
-      File.write(html_path, html)
-
-      result = system('pandoc', '-f', 'html', '-t', 'docx',
-                      "--reference-doc=#{reference_doc}",
-                      '-o', docx_path.to_s, html_path.to_s)
-
-      if result && File.exist?(docx_path)
-        send_data File.read(docx_path, mode: 'rb'),
-                  filename: "#{file_name}.docx",
-                  type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-      else
-        raise "Pandoc conversion failed"
-      end
-    rescue StandardError => e
-      Rails.logger.error("Unable to generate DOCX with Pandoc: #{e.message}")
-      render docx: "#{file_name}.docx",
-            content: clean_html_for_docx_creation(render_to_string(partial: 'shared/export/plan',
-                                                                    locals: { export_format: 'docx' }))
-    ensure
-      File.delete(html_path) if html_path.exist?
-      File.delete(docx_path) if docx_path && File.exist?(docx_path)
-    end
+  # Using and optional locals_assign export_format
+  render docx: "#{file_name}.docx",
+          content: clean_html_for_docx_creation(render_to_string(partial: 'shared/export/plan',
+                                                                locals: { export_format: 'docx' }))
   end
 
   def show_pdf

--- a/app/views/branded/shared/export/_plan.erb
+++ b/app/views/branded/shared/export/_plan.erb
@@ -22,10 +22,7 @@
       <% if @hash[:all_phases] || (@selected_phase.present? && phase[:title] == @selected_phase.title) %>
         <%# Page break before each phase %>
         <div style="page-break-before:always;"></div>
-        <%# Skip H1 for DOCX - Pandoc converts HTML <title> to Word Title style, making H1 redundant %>
-        <% unless local_assigns[:export_format] == 'docx' %>
-          <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
-        <% end %>
+        <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
         <% phase[:sections].each do |section| %>
           <% if display_section?(@hash[:customization], section, @show_custom_sections) && num_section_questions(@plan, section, phase) > 0 %>
             <% if @show_sections %>
@@ -45,8 +42,7 @@
 
                 <% if @show_questions %>
                   <% if (@show_unanswered && blank) || !blank %>
-                    <%# Strip <p> tags to prevent invalid HTML structure (<h3><p>...</p></h3>) %>
-                    <h3><%=  sanitize(question[:text].to_s, scrubber: TableFreeScrubber.new).gsub(/<\/?p>/, '').html_safe %></h3>
+                    <h3><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></h3>
                   <% end %>
                 <% end %>
 

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -22,11 +22,8 @@
       <% if @hash[:all_phases] || (@selected_phase.present? && phase[:title] == @selected_phase.title) %>
         <%# Page break before each phase %>
         <div style="page-break-before:always;"></div>
-        <%# Skip H1 for DOCX - Pandoc converts HTML <title> to Word Title style, making H1 redundant %>
-        <% unless local_assigns[:export_format] == 'docx' %>
-          <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
-          <hr />
-        <% end %>
+        <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
+        <hr />
         <% phase[:sections].each do |section| %>
           <% if display_section?(@hash[:customization], section, @show_custom_sections) && num_section_questions(@plan, section, phase) > 0 %>
             <% if @show_sections %>
@@ -44,12 +41,11 @@
                   <% blank = answer.present? ? answer.blank? : true %>
                   <% options = answer.present? ? answer.question_options : [] %>
                   <% if @show_unanswered %>
-                    <%# Strip <p> tags to prevent invalid HTML (<strong><p>...</p></strong> or <div><p>...</p></div>) %>
                     <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
                     <% if local_assigns[:export_format] && export_format == 'docx' %>
-                      <strong><%=  sanitize(question[:text].to_s, scrubber: TableFreeScrubber.new).gsub(/<\/?p>/, '').html_safe %></strong>
+                      <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
                     <% else %>
-                     <div class="bold"><%=  sanitize(question[:text].to_s, scrubber: TableFreeScrubber.new).gsub(/<\/?p>/, '').html_safe %></div>
+                     <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
                     <% end %>
                     <br>
                   <% end %>


### PR DESCRIPTION
Fixes #[115](https://github.com/CDLUC3/dmptool-doc/issues/115)

- Reverted most of my changes to implement `pandoc` library to convert `HTML` to  `.docx` download because the alignment was still not working on `stg` testing.
- Kept `pandoc` installed though, and kept the `lib/template/pandoc_reference.docx` so that we can try and implement `pandoc` with improvements in the future, after the `PDF` font fix goes live.