### PR TITLE
Fixed bug with question conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v5.55
+- Fixed bug where users could not expand their template sections because the `remove_data` field in the `conditions` table was inadvertently set to `[null]`
+
 ### v5.48
 - Update `template.customize?` method to allow any funder (instead of funder_only)
 - Added bitwise documentation to the `Org` model to help with debugging

--- a/app/helpers/conditions_helper.rb
+++ b/app/helpers/conditions_helper.rb
@@ -186,7 +186,7 @@ module ConditionsHelper
   def condition_to_text(conditions)
     return_string = ''
     conditions.each do |cond|
-      opts = cond.option_list.map { |opt| QuestionOption.find(opt).text }
+      opts = cond.option_list.filter_map { |opt| QuestionOption.find_by(id: opt)&.text }
       return_string += '</dd>' unless return_string.empty?
       return_string += "<dd>#{_('Answering')} "
       return_string += opts.join(' and ')
@@ -196,7 +196,7 @@ module ConditionsHelper
                                 subject_name: subject_string)
       else
         remove_data = cond.remove_data
-        rems = remove_data.map { |rem| "\"#{Question.find(rem).text}\"" }
+        rems = remove_data.filter_map { |rem| Question.find_by(id: rem)&.text&.then { |t| "\"#{t}\"" } }
 
         return_string += _(' will <b>remove</b> question ') if rems.length == 1
         return_string += _(' will <b>remove</b> questions ') if rems.length > 1
@@ -208,7 +208,7 @@ module ConditionsHelper
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def text_formatted(object)
-    text = Question.find(object).text if object.is_a?(Integer)
+    text = Question.find_by(id: object)&.text if object.is_a?(Integer)
     text = object if object.is_a?(String)
     return 'type error' if text.blank?
 

--- a/app/javascript/src/orgAdmin/conditions/updateConditions.js
+++ b/app/javascript/src/orgAdmin/conditions/updateConditions.js
@@ -4,13 +4,16 @@ import { isObject } from '../../utils/isType';
 export default function updateConditions(id) {
   const parent = $(`#${id}.question_container`);
   const content = parent.find('#content');
-  content.html('');
   const addLogicButton = parent.find('a.add-logic[data-remote="true"]');
 
   // display conditions already saved
   if (addLogicButton.length > 0) {
     if (addLogicButton.attr('data-loaded').toString() === 'true') {
-      addLogicButton.trigger('click');
+      // Only wipe and reload via AJAX if the content wasn't already server-rendered
+      if (content.find('.condition-partial').length === 0) {
+        content.html('');
+        addLogicButton.trigger('click');
+      }
     }
   }
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -230,13 +230,13 @@ class Question < ApplicationRecord
     end
 
     if value['action_type'] == 'remove'
-      c.remove_data = value['remove_question_id']
+      c.remove_data = Array(value['remove_question_id']).reject(&:blank?)
       if question_id_map.present?
         new_question_ids = []
         c.remove_data.each do |qid|
           new_question_ids << question_id_map[qid]
         end
-        c.remove_data = new_question_ids
+        c.remove_data = new_question_ids.compact
       end
     else
       c.webhook_data = {

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -55,7 +55,9 @@
     <div class="col-md-3">
       <% if condition[:remove_question_id].is_a?(Array) && condition[:remove_question_id].any? %>
         Question <%= rques[:number] %>: <%= rques.text.gsub(%r{</?p>}, '').slice(0, 50) %>
-        <%= hidden_field_tag(name_start + "[remove_question_id][]", condition[:remove_question_id]) %>
+        <% condition[:remove_question_id].each do |qid| %>
+          <%= hidden_field_tag(name_start + "[remove_question_id][]", qid) %>
+        <% end %>
       <% else %>
         <%
         hook_tip = "Name: #{condition[:webhook_data]['name']}\nEmail: #{condition[:webhook_data]['email']}\n"

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -46,7 +46,9 @@
     %>
     <div class="col-md-3">
       <%= qopt[:text]&.slice(0, 25) %>
-      <%= hidden_field_tag(name_start + "[question_option][]", condition[:question_option_id]) %>
+      <% condition[:question_option_id].each do |qoid| %>
+        <%= hidden_field_tag(name_start + "[question_option][]", qoid) %>
+      <% end %>
     </div>
     <div class="col-md-3">
       <%= condition[:action_type] == 'remove' ? 'Remove' : 'Email' %>


### PR DESCRIPTION

Fixes [176](https://github.com/CDLUC3/dmptool-doc/issues/176)

Changes proposed in this PR:
- Updated `conditions_helper.rb` to allow users to open their template sections even if `remove_data` in `conditions` table is `[null]` or something else problematic
- Updated `question.rb` to add defensive guards which filter out any blank/nil values from form params.
- Updated `_form.html.erb`, which was the main source of the problem because when the `hidden` field contains multiple targets, they passes the whole array as a string, which causes the error. This update iterates over each ID individually.
- Updated `src/orgAdmin/conditions/updateCondition.js` so that it doesn't always wipe the server-rendered condition hidden fields and fire AJAX to reload. Now we skip the wipe if `.condition-partial` is present.

