### PR TITLE
Update robots.txt to include active_storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v5.57
+- Added active storage endpoint to robots.txt
+
 ### v5.56
 - Updated gem dependencies
 - Updated dependencies in `package.json` and `yarn.lock` to address security vulnerabilities.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,3 +7,11 @@
 # Prevent spiders from downloading PDF files.
 User-agent: *
 Disallow: /pdf/
+Disallow: /rails/active_storage/
+
+User-agent: TurnitinBot
+Disallow: /rails/active_storage/
+
+User-agent: Turnitin
+Disallow: /rails/active_storage/
+


### PR DESCRIPTION
Update to robots.txt to prevent crawlers from downloading PDFs