### PR TITLE
Added custom override for 'miami.edu' and 'idsc.miami.edu'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v5.58
+- Added custom override for `idsc.miami.edu` and `miami.edu`
+
 ### v5.57
 - Added active storage endpoint to robots.txt
 

--- a/app/models/concerns/dmptool/org.rb
+++ b/app/models/concerns/dmptool/org.rb
@@ -73,6 +73,18 @@ module Dmptool
           return nil if matches.empty? || matches.first.org_id.nil?
 
           ::Org.find_by(id: matches.first.org_id)
+
+          when "idsc.miami.edu"
+            matches = ::RegistryOrg.where("home_page LIKE '%idsc.miami.edu'")
+            return nil if matches.empty? || matches.first.org_id.nil?
+
+            ::Org.find_by(id: matches.first.org_id)
+
+          when "miami.edu"
+            matches = ::RegistryOrg.where("home_page LIKE '%welcome.miami.edu'")
+            return nil if matches.empty? || matches.first.org_id.nil?
+
+            ::Org.find_by(id: matches.first.org_id)
         else
           nil
         end


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- Added custom override for `idsc.miami.edu` and `miami.edu`

Becky already tested this on Stage and confirmed it's working. Once approved, I'll merge and then plan on pushing up to production next week.
