### PR TITLE
Added Amazon AI bots to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,21 +5,25 @@
 # Disallow: /
 
 # Prevent spiders from downloading PDF files.
+
 User-agent: *
+Crawl-delay: 5
 Disallow: /pdf/
 Disallow: /rails/active_storage/
 
-User-Agent: Amazonbot
-Disallow: /pdf/
-Disallow: /rails/active_storage/
-
-User-Agent: Amzn-SearchBot
-Disallow: /pdf/
-Disallow: /rails/active_storage/
-
-User-agent: TurnitinBot
-Disallow: /rails/active_storage/
-
+User-agent: Amazonbot
+User-agent: Amzn-SearchBot
+User-agent: AmazonProductDiscoverybot
+User-agent: Bytespider
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ClaudeBot
+User-agent: CCBot
+User-agent: Googlebot
+User-agent: Meta-ExternalAgent
 User-agent: Turnitin
+User-agent: TurnitinBot
+Crawl-delay: 10
+Disallow: /pdf/
 Disallow: /rails/active_storage/
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,6 +9,14 @@ User-agent: *
 Disallow: /pdf/
 Disallow: /rails/active_storage/
 
+User-Agent: Amazonbot
+Disallow: /pdf/
+Disallow: /rails/active_storage/
+
+User-Agent: Amzn-SearchBot
+Disallow: /pdf/
+Disallow: /rails/active_storage/
+
 User-agent: TurnitinBot
 Disallow: /rails/active_storage/
 


### PR DESCRIPTION
Added the Amazon AI bots to our robots.txt. The AI bots apparently do not obey the `User-Agent: *` wildcard