### PR TITLE
Fix email hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## DMPTool Releases
 
+### v5.62
+- Fix bug that was using old invalid env variable to set the hosts and mailer domains. Switched to use the AnywayConfig value instead
+
 ### v5.61
 - Upgrade to Rails 8.1
 - Removed override of `yaml_column_permitted_classes` because it is no longer needed in 8.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## DMPTool Releases
 
 ### v5.62
-- Fix bug that was using old invalid env variable to set the hosts and mailer domains. Switched to use the AnywayConfig value instead
+- Fix bug that was using old invalid env variable to set the mailer domains. Switched to use the AnywayConfig value instead
+- Removed the old host rebinding config from environment files because the ENV variable was always nil
 
 ### v5.61
 - Upgrade to Rails 8.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,16 +78,6 @@ Rails.application.configure do
 
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
-
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: ENV['DMPROADMAP_HOST'].present? ? ENV['DMPROADMAP_HOST'] : "example.com" }
+  config.action_mailer.default_url_options = { host: Rails.configuration.x.dmproadmap.server_host.present? ? Rails.configuration.x.dmproadmap.server_host : "example.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -87,7 +87,7 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << ENV['DMPROADMAP_HOST'] if ENV['DMPROADMAP_HOST'].present?
+  config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
+  # config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: ENV['DMPROADMAP_HOST'].present? ? ENV['DMPROADMAP_HOST'] : "example.com" }
+  config.action_mailer.default_url_options = { host: Rails.configuration.x.dmproadmap.server_host.present? ? Rails.configuration.x.dmproadmap.server_host : "example.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -87,7 +87,7 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.hosts << ENV['DMPROADMAP_HOST'] if ENV['DMPROADMAP_HOST'].present?
+  config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -78,16 +78,6 @@ Rails.application.configure do
 
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
-
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  # config.hosts << Rails.configuration.x.dmproadmap.server_host if Rails.configuration.x.dmproadmap.server_host.present?
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)


### PR DESCRIPTION
Fixes an issue caused by the recent Rails 8.1 upgrade that was causing emails to use the default `example.com` host name
